### PR TITLE
Fix broken install and make generated pet themes cuter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@ source/
 **/_raw*.png
 frames_preview.png
 .DS_Store
+
+# 사용자가 생성한 커스텀 펫 테마는 커밋하지 않는다.
+# (특정 반려동물을 식별할 수 있는 이미지 + 런타임 산출물이므로)
+# 기본 제공 테마 4종만 추적한다.
+frames/*/
+!frames/cute/
+!frames/simple/
+!frames/madness/
+!frames/derpy/

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ and immediately applies the new theme in a background thread.
 The same pipeline is available from the command line:
 
 ```bash
-# Install the image-processing dependencies in the project virtual environment
-./.venv/bin/python -m pip install -r requirements-dev.txt
+# The image-processing dependencies ship with requirements.txt, which
+# install_mac.command already installs. For a manual virtual environment:
+./.venv/bin/python -m pip install -r requirements.txt
 
 # Keep OPENAI_API_KEY in the project root .env file
 ./.venv/bin/python vision_theme.py my-pet.jpg my-pet --quality medium

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,2 @@
-# 테마 프레임 생성/변환 및 테스트용 (generate_frames.py, import_theme.py, vision_theme.py)
-Pillow
-numpy
+# 테스트 전용. 앱 실행에 필요한 패키지는 requirements.txt 에 있음
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,8 @@ pyobjc-framework-Cocoa
 openai>=2.46,<3
 pydantic>=2,<3
 python-dotenv>=1.2,<2
+
+# 커스텀 펫 테마 생성 (vision_theme.py, import_theme.py)
+# desktop_cat.py가 로드 시 vision_theme을 import하므로 앱 실행에도 필수
+Pillow>=10,<13
+numpy<3

--- a/vision_theme.py
+++ b/vision_theme.py
@@ -25,23 +25,43 @@ IMAGE_SIZE = "1536x1024"
 DEFAULT_QUALITY = "medium"
 QUALITY_CHOICES = ("low", "medium", "high")
 FRAMES_DIR = Path(__file__).with_name("frames")
-MIN_DETECTED_STAGES = 4
-MAX_DETECTED_STAGES = 8
+MIN_DETECTED_STAGES = 6
+MAX_DETECTED_STAGES = 6
 
 SHEET_PROMPT = """\
 Use the attached photo as the identity reference and create a horizontal sprite sheet.
 Preserve the distinctive fur color, markings, face, and ear shape of THIS exact pet.
-Depict the same cat or dog six times from left to right in a charming sticker/cartoon style.
-Keep all six full-body characters in the same pose, scale family, viewing angle, and art style.
-Make the body grow progressively fatter from left to right: character 1 is slim, character 2
-is slightly plump, character 3 is chubby, character 4 is very chubby, character 5 is round,
-and character 6 is extremely round. Use a pure white background and clear white space between
-every character. Show exactly one horizontal row. no text, no labels, no watermark, no borders.
+Depict the same pet six times from left to right as a soft 3D toy figurine: smooth matte
+vinyl surface, large simplified rounded forms, NO individual fur strands and no fine line
+hatching, soft studio lighting with gentle rim light and soft shading on the body itself.
+Chibi proportions: oversized round head, very large glossy dark eyes with two white
+catchlights, tiny rounded paws, short stubby legs, small soft blush on the cheeks.
+Keep the same character identity, three-quarter front-facing angle, and art style in all six.
+Make the body grow fatter AND the pose grow lazier from left to right:
+1 slim, sitting upright and tall, bright wide open eyes;
+2 slightly plump, sitting, soft closed smile;
+3 chubby, sitting low with legs tucked in, relaxed eyes;
+4 very chubby, crouching down, half-closed sleepy eyes;
+5 round, lying down as a flat loaf with front paws tucked, eyes nearly shut;
+6 extremely round, melting flat and wide on the ground like a pancake, eyes fully closed in
+a happy curve.
+Each character must be clearly bigger and lower to the ground than the previous one, so the
+silhouette changes from tall and narrow to short and wide.
+Give every character a soft contour slightly darker than the background so the silhouette
+stays readable even for white or cream fur.
+Draw the characters large so they fill most of the image height.
+Use a pure white background. Leave a wide empty white gap between neighboring
+characters, at least half a character wide, so that no two characters ever touch or overlap.
+Show exactly one horizontal row of exactly six characters, evenly spaced. no text, no labels, no watermark, no borders, no cast
+shadow on the ground, nothing connecting two characters.
 """
 
 RETRY_PROMPT = """\
-exactly 6 clearly separated cats with wide white gaps between them. Keep every character fully
-separate with no touching, overlap, props, shadows connecting characters, or extra figures.
+exactly 6 clearly separated characters in one horizontal row, with wide pure white gaps
+between them. Keep every character fully separate: no touching, no overlap, no props, no
+ground shadow, no reflection, no extra figures, no partial characters cropped at the left or
+right edge. The background must be uniform pure white #FFFFFF with no gradient, no texture,
+and no off-white tint anywhere.
 """
 
 _GENERATION_QUALITY = ContextVar(


### PR DESCRIPTION
## 왜

새로 clone한 사용자가 `install_mac.command`를 실행하면 앱이 뜨지 않았습니다. 깨끗한 venv에서 재현했습니다:

```
File "desktop_cat.py", line 53, in <module>
  from vision_theme import ThemeGenerationError, build_theme as build_pet_theme
File "vision_theme.py", line 18, in <module>
  from PIL import Image
ModuleNotFoundError: No module named 'PIL'
```

`desktop_cat.py`가 로드 시점에 `vision_theme`을 import하는데, Pillow와 numpy가 `requirements-dev.txt`에만 있었고 설치 스크립트는 `requirements.txt`만 설치합니다. 7/20 펫 테마 메뉴를 추가하면서 생긴 의존성이 반영되지 않았습니다. 설치 스크립트가 로그를 `cat.log`로 보내기 때문에 사용자는 에러를 보지 못하고 "고양이가 안 뜬다"만 겪습니다.

## 무엇을

**런타임 의존성** — Pillow/numpy를 `requirements.txt`로 옮기고 상한을 지정했습니다. `requirements-dev.txt`는 테스트 전용이 되었고, README의 설치 안내도 맞췄습니다.

**커스텀 테마 커밋 방지** — `frames/`는 기본 테마 4종만 추적합니다. 사용자 사진으로 생성한 테마는 식별 가능한 동물이 담긴 런타임 산출물이고, 커밋되면 다음 생성 테마의 인덱스도 밀립니다.

**생성 테마 품질** — 기존 프롬프트는 여섯 캐릭터가 같은 자세를 유지하도록 요구해서, 생성된 펫이 옆으로만 부풀고 단계 구분이 되지 않았습니다. 3D 토이 스타일과 단계별 자세·표정을 명시하도록 바꿨습니다. 단계 검출도 정확히 6개로 좁혔습니다 — 기존 4~8 범위는 두 캐릭터가 붙은 시트를 5단계로 통과시켜 한 프레임에 펫 두 마리가 들어가는 결과를 냈습니다.

## 검증

- 새 venv(Python 3.9) + `requirements.txt`만 설치 → `import desktop_cat` 성공, 수정 전 동일 절차는 `ModuleNotFoundError`로 실패함을 재현
- `pytest` 66 passed, 2 skipped (라이브 API 테스트는 환경변수 게이트)
- `git ls-files frames/ | wc -l` = 171 (기본 테마 추적 유지), `git add .` 시 생성 테마 폴더가 포함되지 않음
- 실사진으로 테마 생성 2회 실행 — 6단계 정상 검출, 자세·표정 변화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)