### PR TITLE
Document what the Windows build includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ automatically converts into a custom 40-frame desktop theme.
 - **Useful at a glance:** disk, RAM, swap, and top memory-consuming apps appear
   in the right-click menu. The cat can be dragged, resized, and rethemed.
 
+The AI-powered items above are macOS only. See
+[Install on Windows](#install-on-windows) for what the Windows build covers.
+
 ## Privacy
 
 Chonky Cat does not phone home. Disk, RAM, and swap numbers are measured and
@@ -137,6 +140,12 @@ Store `OPENAI_API_KEY` in a `.env` file at the project root to enable GPT-5.6
 diagnosis and custom pet theme generation.
 
 ## Install on Windows
+
+> **What the Windows build includes.** The disk-driven cat, RAM and swap
+> readouts, top memory consumers, and theme and size switching. The AI features
+> are macOS only: the 🐾 Feeling full? diagnosis, custom pet themes, safe
+> cleanup, personalities, and the language toggle. In exchange the Windows
+> build has no OpenAI dependency and makes no network requests at all.
 
 See [`windows/README.txt`](windows/README.txt) for the full instructions. In
 short:


### PR DESCRIPTION
## 왜

README의 Highlights는 macOS 기준으로 쓰여 있는데, 윈도우 버전(`windows/windows_cat.pyw`)에는 AI 기능이 하나도 없습니다. 코드로 확인한 결과 diagnosis / vision_theme / openai / cleanup / personality / i18n 관련 문자열이 **전부 0건**입니다.

지금 상태로는 윈도우 사용자가 "🐾 배불러?" 같은 기능을 기대하고 설치했다가 없는 걸 발견하게 됩니다.

## 무엇을

`Install on Windows` 섹션 상단에 윈도우 빌드의 실제 범위를 명시하고, Highlights 끝에서 그 섹션으로 안내합니다.

윈도우 빌드에 있는 것: 디스크 연동 고양이, RAM·스왑 표시, 메모리 상위 앱, 테마·크기 변경.
macOS 전용: 진단, 커스텀 펫 테마, 안전 정리, 성격, 언어 토글.

대신 윈도우 빌드는 OpenAI 의존성이 없고 네트워크 요청을 전혀 하지 않는다는 점을 함께 적었습니다 — 이건 실제로 윈도우 쪽의 장점입니다.

## 검증

맥에서 PySide6를 설치하고 `windows_cat.pyw`를 헤드리스로 로드해 확인했습니다:

```
모듈 로드      : 성공 (PySide6 6.10.3, psutil 7.2.2)
테마 인식      : ['cute', 'simple', 'madness', 'derpy']
cute 프레임    : 40개
디스크 측정    : 정상
top_memory_apps: 정상
```

경로는 `os.path.join`으로, 설정 파일 입출력은 `encoding="utf-8"`로 처리되어 있어 Windows에서의 구분자·인코딩 문제도 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)