### PR TITLE
Fix the three release blockers and bring main up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ cd memory-cat
 The installer requires Python 3.9 or later. It creates `.venv`, installs the
 dependencies, launches Memory Cat, and configures it to start at login.
 
+On a Mac that has never had developer tools installed, `python3` is only a stub
+that prompts you to install them. Run `xcode-select --install` first, then run
+the installer again. The installer checks for this and tells you what to do.
+
 To remove it, run:
 
 ```bash

--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -415,8 +415,18 @@ class CatController(NSObject):
         self.view.setBob_(math.sin(self.phase) * (2.0 + 3.0 * self.score / 100.0))
 
     def refresh_(self, timer):
+        # NSTimer 콜백에서 예외가 새어 나가면 run loop 가 그대로 끝나 앱이
+        # 종료된다. LaunchAgent 에 KeepAlive 가 없어 재로그인 전까지 되살아나지
+        # 않으므로, 한 틱이 실패해도 삼키고 다음 틱을 기다린다.
+        try:
+            self._refresh_once()
+        except Exception:
+            pass
+
+    @objc.python_method
+    def _refresh_once(self):
         disk = mc.disk_usage()
-        score, vm, sw = mc.pressure_score()
+        score, vm, sw = mc.safe_pressure_score()
         dpct = disk.percent
         self.score = dpct
         self._maybe_prompt_disk_full(dpct)

--- a/install_mac.command
+++ b/install_mac.command
@@ -3,6 +3,21 @@ set -e
 cd "$(dirname "$0")"
 echo "🐱 메모리 뚱냥이 설치 중..."
 
+# 개발자 도구가 없는 Mac 에서 /usr/bin/python3 는 실제 인터프리터가 아니라
+# 설치를 유도하는 껍데기다. 그대로 두면 set -e 가 걸려 아무 안내 없이 끝난다.
+if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)' 2>/dev/null; then
+    echo ""
+    echo "❌ Python 3.9 이상이 필요한데 실행할 수 있는 python3 를 찾지 못했어요."
+    echo ""
+    echo "   macOS 개발자 도구를 아직 설치하지 않았다면 먼저 실행하세요:"
+    echo "       xcode-select --install"
+    echo "   설치 창이 끝나면 이 파일을 다시 실행하면 됩니다."
+    echo ""
+    echo "   또는 https://www.python.org/downloads/ 에서 설치해도 됩니다."
+    echo ""
+    exit 1
+fi
+
 python3 -m venv .venv
 ./.venv/bin/python -m pip install -q --upgrade pip
 ./.venv/bin/python -m pip install -q -r requirements.txt

--- a/metrics.py
+++ b/metrics.py
@@ -2,6 +2,7 @@
 """메모리/디스크 측정 공유 모듈 (플랫폼 공통, GUI 의존 없음)."""
 import math
 import os
+from types import SimpleNamespace
 
 import psutil
 
@@ -46,6 +47,21 @@ def pressure_score():
     vm = psutil.virtual_memory()
     sw = psutil.swap_memory()
     return 0.6 * vm.percent + 0.4 * sw.percent, vm, sw
+
+
+def safe_pressure_score():
+    """스왑 조회가 실패해도 RAM 기준 점수를 돌려준다.
+
+    일부 psutil/macOS 조합은 ``swap_memory()`` 만 OSError 를 낸다. 알 수 없는
+    스왑을 사용 중이라고 추측하지 않고 0 으로 두며 RAM 측정은 유지한다.
+    ``brain.collect_metrics`` 와 같은 처리를 GUI 타이머에서도 쓰기 위한 것.
+    """
+    try:
+        return pressure_score()
+    except OSError:
+        vm = psutil.virtual_memory()
+        sw = SimpleNamespace(total=0, used=0, percent=0.0)
+        return 0.6 * vm.percent, vm, sw
 
 
 def top_memory_apps(limit=5):

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -2,6 +2,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock, call, mock_open, patch
 
 import i18n
@@ -648,6 +649,44 @@ class DesktopCatTests(unittest.TestCase):
         self.assertEqual(
             summary,
             {"moved": 1, "already_in_trash": 1, "skipped": 1, "failed": 0},
+        )
+
+    def test_refresh_swallows_measurement_failure_so_the_timer_survives(self):
+        controller = desktop_cat.CatController.alloc().init()
+        controller._refresh_once = Mock(side_effect=OSError("swap unavailable"))
+
+        # NSTimer 콜백에서 예외가 새어 나가면 run loop 가 끝나 앱이 종료된다.
+        controller.refresh_(None)
+
+        controller._refresh_once.assert_called_once_with()
+
+    def test_refresh_uses_the_swap_tolerant_measurement(self):
+        controller = desktop_cat.CatController.alloc().init()
+        controller.cfg = dict(desktop_cat.DEFAULT)
+        controller.language = "ko"
+        controller.view = Mock()
+        controller._maybe_prompt_disk_full = Mock()
+        disk = SimpleNamespace(
+            total=100, used=50, free=50, percent=50.0
+        )
+        vm = SimpleNamespace(total=8, used=4, percent=50.0)
+        sw = SimpleNamespace(total=0, used=0, percent=0.0)
+
+        with (
+            patch.object(desktop_cat.mc, "disk_usage", return_value=disk),
+            patch.object(
+                desktop_cat.mc, "safe_pressure_score", return_value=(30.0, vm, sw)
+            ) as measure,
+            patch.object(desktop_cat.mc, "top_memory_apps", return_value=[]),
+            patch.object(desktop_cat, "NSImage"),
+        ):
+            controller.refresh_(None)
+
+        measure.assert_called_once_with()
+        self.assertEqual(controller.score, 50.0)
+        # 스왑을 못 읽은 경우 스왑 줄은 넣지 않는다.
+        self.assertNotIn(
+            "스왑", "".join(controller.detail)
         )
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,6 @@
 import unittest
 from collections import namedtuple
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import metrics
@@ -75,6 +76,30 @@ class MetricsTests(unittest.TestCase):
                 ):
                     usage = metrics.disk_usage()
                 self.assertIs(usage, measured)
+
+    def test_safe_pressure_score_keeps_ram_when_swap_lookup_fails(self):
+        vm = SimpleNamespace(total=8, used=4, percent=50.0)
+        with (
+            patch.object(metrics.psutil, "swap_memory", side_effect=OSError("boom")),
+            patch.object(metrics.psutil, "virtual_memory", return_value=vm),
+        ):
+            score, measured_vm, swap = metrics.safe_pressure_score()
+
+        self.assertAlmostEqual(score, 30.0)
+        self.assertIs(measured_vm, vm)
+        self.assertEqual((swap.total, swap.used, swap.percent), (0, 0, 0.0))
+
+    def test_safe_pressure_score_passes_swap_through_when_available(self):
+        vm = SimpleNamespace(total=8, used=4, percent=50.0)
+        sw = SimpleNamespace(total=2, used=1, percent=25.0)
+        with (
+            patch.object(metrics.psutil, "swap_memory", return_value=sw),
+            patch.object(metrics.psutil, "virtual_memory", return_value=vm),
+        ):
+            score, measured_vm, swap = metrics.safe_pressure_score()
+
+        self.assertAlmostEqual(score, 40.0)
+        self.assertIs(swap, sw)
 
 
 if __name__ == "__main__":

--- a/windows/windows_cat.pyw
+++ b/windows/windows_cat.pyw
@@ -13,6 +13,7 @@ import json
 import math
 import os
 import sys
+from types import SimpleNamespace
 
 import psutil
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -155,9 +156,21 @@ class Cat(QtWidgets.QWidget):
 
     # ---------------------------------------------------------- data
     def refresh(self):
+        # QTimer 슬롯에서 예외가 새어 나가면 PySide6 버전에 따라 앱이 그대로
+        # 종료된다. 한 틱이 실패해도 삼키고 다음 틱을 기다린다.
+        try:
+            self._refresh_once()
+        except Exception:
+            pass
+
+    def _refresh_once(self):
         disk = disk_usage()
         vm = psutil.virtual_memory()
-        sw = psutil.swap_memory()
+        try:
+            sw = psutil.swap_memory()
+        except OSError:
+            # 일부 환경은 swap_memory() 만 실패한다. 스왑을 0 으로 두고 계속한다.
+            sw = SimpleNamespace(total=0, used=0, percent=0.0)
         dpct = disk.percent
         self.score = dpct
         theme = self.cfg["theme"]


### PR DESCRIPTION
`main` is currently the branch a stranger clones, and it is broken: its test suite fails, its README still calls the app "Chonky Cat", and it tells Windows users to run the build script from the repo root. This branch merges the seven commits that were already waiting plus two new fixes.

## The two new fixes

**The refresh timer could take the whole app down.** An exception raised inside the `NSTimer` callback propagates out of the run loop and ends it, so the process exits — and the LaunchAgent has no `KeepAlive`, so the cat stays gone until the next login. `brain.collect_metrics` already guarded `pressure_score()` against the `OSError` some psutil/macOS combinations raise from `swap_memory()`; the GUI timer was missing that guard. `metrics.safe_pressure_score()` now shares that handling so the cat keeps updating on those machines instead of freezing, and the whole tick is wrapped so no future failure in `refresh_` can kill the run loop. The PySide6 slot in the Windows build had the same shape and gets the same treatment.

**The installer gave up silently on a clean Mac.** Where developer tools have never been installed, `/usr/bin/python3` is a stub that triggers the Command Line Tools prompt and exits non-zero, so `set -e` stopped the script at `python3 -m venv .venv` — no `.venv`, no cat, no explanation. The installer now checks for a usable interpreter first and points at `xcode-select --install`, and the README says the same so "requires Python 3.9 or later" is not read as "you already have it".

## Verification

- Full suite on a fresh clone of the merged result: **72 passed, 2 skipped** on both Python 3.14 and Python 3.9. 3.9 matters because stock macOS `python3` is 3.9.6 and that is what `install_mac.command` uses.
- The run-loop fix was confirmed against a real `NSTimer`: before it, a raising callback ended the run loop on the first tick; after it, the timer fires repeatedly and the app survives.
- Four regression tests added covering the swap fallback and the timer guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)