### PR TITLE
Ship Memory Cat as a real .app bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Memory Cat does not phone home. Disk, RAM, and swap numbers are measured and
 drawn entirely on your machine, and nothing is collected or sent anywhere in
 the background. There is no analytics, telemetry, or crash reporting in the
 codebase. (The macOS installer does route the app's own stdout and stderr to a
-local `cat.log` beside the app, which never leaves your machine.)
+local `cat.log` under `~/Library/Logs/Memory Cat/`, which never leaves your
+machine.)
 
 Two features reach the network, and only when you click them yourself:
 
@@ -122,28 +123,63 @@ cd memory-cat
 ./install_mac.command        # You can also double-click this file
 ```
 
-The installer requires Python 3.9 or later. It creates `.venv`, installs the
-dependencies, launches Memory Cat, and configures it to start at login.
+The installer requires Python 3.9 or later. It builds a real application
+bundle at `~/Applications/Memory Cat.app`, installs the dependencies into a
+virtual environment inside that bundle, launches Memory Cat, and configures it
+to start at login.
+
+Because everything the app needs lives in the bundle, **you can delete the
+cloned repository afterwards** and Memory Cat keeps working.
 
 On a Mac that has never had developer tools installed, `python3` is only a stub
 that prompts you to install them. Run `xcode-select --install` first, then run
 the installer again. The installer checks for this and tells you what to do.
 
-To remove it, run:
+### Where your files live
+
+| What | Where |
+| --- | --- |
+| The app | `~/Applications/Memory Cat.app` |
+| Settings (`config.json`) | `~/Library/Application Support/Memory Cat/` |
+| Themes you generated | `~/Library/Application Support/Memory Cat/frames/` |
+| `OPENAI_API_KEY` (`.env`) | `~/Library/Application Support/Memory Cat/` |
+| Log | `~/Library/Logs/Memory Cat/cat.log` |
+| Login item | `~/Library/LaunchAgents/com.memorycat.desktop.plist` |
+
+The four built-in themes ship inside the bundle and are replaced on every
+install. Anything you made stays in Application Support and is never
+overwritten.
+
+**Upgrading from an older install?** The installer copies your existing
+`config.json`, `.env`, and any custom `frames/<name>/` folders out of the
+repository and into Application Support on first run. It copies rather than
+moves, so the originals in your clone are left untouched, and it never
+overwrites a file that is already there.
+
+### Removing it
 
 ```bash
 ./uninstall_mac.command
 ```
 
-After pulling a new version, restart the app so the updated code is loaded —
-a running instance keeps the modules it imported at launch:
+If you already deleted the repository, the same script is kept inside the app:
 
 ```bash
-pkill -f desktop_cat.py && ./.venv/bin/python desktop_cat.py &
+"$HOME/Applications/Memory Cat.app/Contents/Resources/uninstall_mac.command"
 ```
 
-Store `OPENAI_API_KEY` in a `.env` file at the project root to enable GPT-5.6
-diagnosis and custom pet theme generation.
+Either way it stops the app, removes the login item and the bundle, and leaves
+your settings and custom themes alone. It prints the one command that deletes
+those too, if that is what you want.
+
+### Updating
+
+Pull, then run `./install_mac.command` again. It stops the running app,
+rebuilds the bundle, and restarts it.
+
+Store `OPENAI_API_KEY` in `~/Library/Application Support/Memory Cat/.env` to
+enable GPT-5.6 diagnosis and custom pet theme generation. When you run from a
+clone for development, a `.env` in the project root still works.
 
 ## Install on Windows
 
@@ -196,8 +232,10 @@ and immediately applies the new theme in a background thread.
 The same pipeline is available from the command line:
 
 ```bash
-# The image-processing dependencies ship with requirements.txt, which
-# install_mac.command already installs. For a manual virtual environment:
+# install_mac.command builds its virtual environment inside the app bundle.
+# For a development environment in the clone, make your own:
+python3 -m venv .venv
+./.venv/bin/python -m pip install --upgrade pip   # stock pip cannot resolve pyobjc-core
 ./.venv/bin/python -m pip install -r requirements.txt
 
 # Keep OPENAI_API_KEY in the project root .env file
@@ -206,8 +244,9 @@ The same pipeline is available from the command line:
 
 `vision_theme.py` asks gpt-image-2 for six clearly separated versions of the
 same pet, from slim to extremely round. It then reuses the existing import
-pipeline to produce `frames/my-pet/cat_00.png` through `cat_39.png`, plus preview
-and raw debug images.
+pipeline to produce `cat_00.png` through `cat_39.png` under
+`~/Library/Application Support/Memory Cat/frames/my-pet/`, plus preview and raw
+debug images. Set `MEMORY_CAT_HOME` to write somewhere else.
 
 ### From an existing sprite sheet
 
@@ -218,14 +257,19 @@ import it directly:
 ./.venv/bin/python import_theme.py my-sprite-sheet.png my-theme
 ```
 
-Themes under `frames/<name>/` are discovered automatically. Reopen the
-right-click **Theme** menu to select a newly imported theme. Code-generated
-built-in themes can be rebuilt with `python generate_frames.py`.
+Themes are discovered automatically from two places: the four built-in themes
+inside the app bundle, and your own themes in
+`~/Library/Application Support/Memory Cat/frames/<name>/`. Newly generated
+themes always go to the second one, so reinstalling the app never deletes them.
+Reopen the right-click **Theme** menu to select a newly imported theme.
+Code-generated built-in themes can be rebuilt with `python generate_frames.py`.
 
 ## Project structure
 
 ```text
 desktop_cat.py      macOS desktop app and menus (PyObjC)
+apppaths.py         where bundled assets end and user data begins
+macos/build_app.py  assembles Memory Cat.app and the LaunchAgent plist
 brain.py            GPT-5.6 performance diagnosis and safe Trash workflow
 personality.py      personality presets and custom prompt compiler
 i18n.py             English/Korean UI strings and chonk-stage names
@@ -244,6 +288,11 @@ tests/              mocked, regression, and optional live API tests
   tests so personal settings are not read or modified.
 - `MEMORY_CAT_DEMO_DISK_PERCENT=92`: replace measured disk usage with a demo or
   test value, clamped to 0–100; displayed and diagnostic values stay consistent.
+- `MEMORY_CAT_HOME=/tmp/cat-home`: relocate everything under
+  `~/Library/Application Support/Memory Cat/` — settings, custom themes, and
+  `.env` — so a test run cannot touch your real data.
+- `MEMORY_CAT_APPS_DIR=/tmp/apps`: install the bundle somewhere other than
+  `~/Applications`. Used by `install_mac.command` and `uninstall_mac.command`.
 
 Example:
 

--- a/apppaths.py
+++ b/apppaths.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""메모리 뚱냥이가 쓰는 경로를 한 곳에서 정한다.
+
+앱을 `.app` 번들로 설치하면 소스와 기본 테마는 번들 안(사실상 읽기 전용)에
+들어가고, 사용자가 만든 것들은 번들 밖에 남아야 한다. 그래서 경로를 두 종류로
+나눈다.
+
+* **번들 자원** — `desktop_cat.py` 옆에 있는 것들. 기본 테마 4종이 여기 있다.
+  앱을 다시 설치하면 통째로 덮어써진다.
+* **사용자 데이터** — ``~/Library/Application Support/Memory Cat/``.
+  설정(``config.json``), 직접 만든 펫 테마(``frames/mypet*``), API 키(``.env``)가
+  여기 있다. 앱을 지워도, 저장소 폴더를 지워도 남는다.
+
+저장소에서 바로 실행하는 개발 환경에서도 같은 규칙이 적용된다. 다만 ``.env`` 는
+저장소 옆에 두는 관행이 있어서 사용자 데이터 쪽을 먼저 보고 없으면 소스 옆을
+본다(:func:`dotenv_candidates`).
+"""
+
+import os
+from pathlib import Path
+
+APP_NAME = "Memory Cat"
+BUNDLE_ID = "com.memorycat.desktop"
+
+#: 번들 안에 함께 배포되는 기본 테마. 이 이름들만 번들로 복사한다.
+BUNDLED_THEMES = ("cute", "simple", "madness", "derpy")
+
+#: 사용자 데이터 위치를 통째로 옮기고 싶을 때 쓰는 탈출구(주로 테스트용).
+HOME_ENV = "MEMORY_CAT_HOME"
+
+_SOURCE_DIR = Path(__file__).resolve().parent
+
+
+def source_dir() -> Path:
+    """앱 소스와 기본 테마가 놓인 폴더(번들이면 ``Contents/Resources``)."""
+    return _SOURCE_DIR
+
+
+def bundled_frames_dir() -> Path:
+    """기본 테마가 들어 있는 읽기 전용 ``frames/``."""
+    return _SOURCE_DIR / "frames"
+
+
+def user_data_dir() -> Path:
+    """설정·커스텀 테마·API 키가 사는 곳. 없으면 만들지는 않는다."""
+    override = os.environ.get(HOME_ENV)
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / "Library" / "Application Support" / APP_NAME
+
+
+def ensure_user_data_dir() -> Path:
+    """:func:`user_data_dir` 을 만들어서 돌려준다. 실패해도 예외는 안 낸다."""
+    target = user_data_dir()
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    return target
+
+
+def user_frames_dir() -> Path:
+    """사용자가 만든 테마가 쌓이는 ``frames/``."""
+    return user_data_dir() / "frames"
+
+
+def config_file() -> Path:
+    return user_data_dir() / "config.json"
+
+
+def log_dir() -> Path:
+    return Path.home() / "Library" / "Logs" / APP_NAME
+
+
+def dotenv_candidates():
+    """``.env`` 를 찾을 순서. 사용자 데이터가 먼저, 소스 옆이 나중."""
+    return (user_data_dir() / ".env", _SOURCE_DIR / ".env")
+
+
+def theme_roots():
+    """테마를 찾을 폴더들. 뒤쪽이 앞쪽을 가린다(사용자 테마 우선)."""
+    return (bundled_frames_dir(), user_frames_dir())
+
+
+def theme_dir(theme):
+    """테마 이름 하나를 실제 폴더로 바꾼다. 사용자 테마가 기본 테마를 이긴다.
+
+    어느 쪽에도 없으면 사용자 쪽 경로를 돌려준다. 호출부는 어차피
+    ``os.listdir`` 실패를 감싸고 있어서 없는 경로가 와도 괜찮다.
+    """
+    name = str(theme)
+    fallback = user_frames_dir() / name
+    for root in reversed(theme_roots()):
+        candidate = root / name
+        if candidate.is_dir():
+            return candidate
+    return fallback

--- a/brain.py
+++ b/brain.py
@@ -16,6 +16,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 from pydantic import BaseModel
 
+import apppaths
 from i18n import LANGUAGE_EN, LANGUAGE_KO, canonical_language, chonk_stage
 from metrics import disk_usage, human_gb, pressure_score, top_memory_apps
 from personality import DEFAULT_PERSONALITY, compile_personality
@@ -502,7 +503,10 @@ def _assemble_result(
 
 
 def _load_api_key() -> Optional[str]:
-    load_dotenv(Path(__file__).with_name(".env"), override=False)
+    # 설치된 앱은 사용자 폴더의 .env 를, 저장소에서 바로 돌릴 때는 소스 옆의
+    # .env 를 읽는다. override=False 라서 먼저 읽힌 쪽이 이긴다.
+    for candidate in apppaths.dotenv_candidates():
+        load_dotenv(candidate, override=False)
     return os.getenv("OPENAI_API_KEY")
 
 

--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -3,9 +3,11 @@
 
 항상 위에 떠 있는 작은 고양이. 디스크(하드 용량)가 차오를수록
 애기냥 -> 돼지냥으로 빵빵해지며 살짝 통통 튄다. 라벨에 디스크/램 표시.
-우클릭: AI 진단 + 성격 + 테마 + 크기 + 새로고침/종료. 설정은 config.json 에 저장.
+우클릭: AI 진단 + 성격 + 테마 + 크기 + 새로고침/종료.
 
-테마는 frames/<이름>/ 폴더를 자동 인식한다. 새 테마 추가:
+설정과 직접 만든 테마는 ``~/Library/Application Support/Memory Cat/`` 에,
+기본 테마 4종은 앱 번들 안에 있다(:mod:`apppaths` 참고). 두 곳을 모두 훑어서
+테마 목록을 만든다. 새 테마 추가:
   python import_theme.py 내이미지.png 테마이름   (가로 N단계 시트)
 """
 import json
@@ -31,6 +33,7 @@ from Foundation import (
     NSOperationQueue, NSUserNotification, NSUserNotificationCenter,
 )
 
+import apppaths
 import metrics as mc
 from brain import diagnose as run_diagnosis, safe_trash
 from i18n import (
@@ -54,9 +57,12 @@ from personality import (
 from vision_theme import ThemeGenerationError, build_theme as build_pet_theme
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-FRAMES_BASE = os.path.join(HERE, "frames")
+# 기본 테마 4종은 앱(번들) 안에, 사용자가 만든 테마는 사용자 폴더에 산다.
+# 자세한 규칙은 apppaths 모듈 참고.
+FRAMES_BASE = str(apppaths.bundled_frames_dir())
+USER_FRAMES_BASE = str(apppaths.user_frames_dir())
 ALERT_ICON_PATH = os.path.join(FRAMES_BASE, "cute", "cat_00.png")
-CONFIG = os.path.join(HERE, "config.json")
+CONFIG = str(apppaths.config_file())
 REFRESH_SEC = 4.0
 DISK_FULL_NOTIFICATION_ID = "memory-cat-disk-full"
 # 알림이 배달 목록에 반영되는 데 걸리는 시간을 넉넉히 잡은 값.
@@ -136,6 +142,10 @@ def save_config(cfg, path=None):
     if path is None:
         path = config_path()
     try:
+        # 첫 실행이면 ~/Library/Application Support/Memory Cat/ 이 아직 없다.
+        parent = os.path.dirname(os.path.abspath(path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
         with open(path, "w", encoding="utf-8") as handle:
             json.dump(cfg, handle, ensure_ascii=False)
         return True
@@ -274,12 +284,35 @@ def process_cleanup_recommendations(recommendations, confirm_item, trash_func=No
     return summary
 
 
+def theme_roots():
+    """테마를 찾을 폴더 목록. 번들 기본 테마 + 사용자가 만든 테마."""
+    return [FRAMES_BASE, USER_FRAMES_BASE]
+
+
+def theme_dir(theme):
+    """테마 이름을 실제 폴더 경로로. 같은 이름이면 사용자 테마가 이긴다."""
+    name = str(theme)
+    for root in reversed(theme_roots()):
+        candidate = os.path.join(root, name)
+        if os.path.isdir(candidate):
+            return candidate
+    return os.path.join(USER_FRAMES_BASE, name)
+
+
 def discover_themes():
-    """frames/ 안의 테마 폴더 자동 인식. 알려진 것 먼저, 나머지 알파벳순."""
+    """테마 폴더 자동 인식. 알려진 것 먼저, 나머지 알파벳순.
+
+    번들 안 기본 테마와 사용자 폴더의 커스텀 테마를 함께 본다. 두 곳에 같은
+    이름이 있으면 한 번만 나온다(그리고 :func:`theme_dir` 이 사용자 쪽을 고른다).
+    """
     found = []
-    if os.path.isdir(FRAMES_BASE):
-        for n in sorted(os.listdir(FRAMES_BASE)):
-            d = os.path.join(FRAMES_BASE, n)
+    for root in theme_roots():
+        if not os.path.isdir(root):
+            continue
+        for n in sorted(os.listdir(root)):
+            d = os.path.join(root, n)
+            if n in found or n.startswith("."):
+                continue
             if os.path.isdir(d) and os.path.exists(os.path.join(d, "cat_00.png")):
                 found.append(n)
     return ([t for t in THEME_ORDER if t in found]
@@ -287,11 +320,15 @@ def discover_themes():
 
 
 def next_pet_theme_name(frames_base=None):
-    """Return mypet, mypet2, ... without overwriting an existing path."""
-    root = FRAMES_BASE if frames_base is None else os.fspath(frames_base)
+    """Return mypet, mypet2, ... without overwriting an existing path.
+
+    ``frames_base`` 를 주지 않으면 번들과 사용자 폴더를 모두 확인한다.
+    한쪽에만 있는 이름을 재사용하면 기본 테마를 가려 버리기 때문이다.
+    """
+    roots = theme_roots() if frames_base is None else [os.fspath(frames_base)]
     candidate = "mypet"
     suffix = 2
-    while os.path.exists(os.path.join(root, candidate)):
+    while any(os.path.exists(os.path.join(root, candidate)) for root in roots):
         candidate = f"mypet{suffix}"
         suffix += 1
     return candidate
@@ -308,7 +345,7 @@ def size_label(key, language=LANGUAGE_KO):
 
 
 def frame_count(theme):
-    d = os.path.join(FRAMES_BASE, theme)
+    d = theme_dir(theme)
     try:
         return max(1, len([f for f in os.listdir(d)
                            if f.startswith("cat_") and f.endswith(".png")]))
@@ -319,7 +356,7 @@ def frame_count(theme):
 def frame_path(theme, idx):
     n = frame_count(theme)
     idx = max(0, min(n - 1, idx))
-    return os.path.join(FRAMES_BASE, theme, f"cat_{idx:02d}.png")
+    return os.path.join(theme_dir(theme), f"cat_{idx:02d}.png")
 
 
 def layout_for(cat):

--- a/import_theme.py
+++ b/import_theme.py
@@ -6,7 +6,8 @@
 가로로 늘어선 N단계 고양이 시트를 받아서:
   1) 흰 배경을 가장자리부터 flood-fill 로 투명 처리 (안쪽 흰 배는 보존)
   2) 단계별로 잘라 정사각형 캔버스에 정렬 (기본: 바닥 정렬)
-  3) 11단계(cat_00~10)로 매핑해 frames/<테마>/ 에 저장
+  3) 11단계(cat_00~10)로 매핑해
+     ~/Library/Application Support/Memory Cat/frames/<테마>/ 에 저장
 """
 import math
 import os
@@ -14,6 +15,8 @@ import sys
 
 import numpy as np
 from PIL import Image, ImageDraw
+
+import apppaths
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 FINAL = 240
@@ -119,7 +122,9 @@ def main():
         sys.exit(1)
 
     smooth = "--smooth" in sys.argv   # 자세 비슷할 때만 권장 (다르면 잔상)
-    out = os.path.join(HERE, "frames", theme)
+    # 직접 만든 테마는 앱 번들이 아니라 사용자 폴더에 쌓인다. 앱을 다시 깔아도
+    # 살아남고, 저장소를 지워도 남는다.
+    out = os.path.join(apppaths.user_frames_dir(), theme)
     save_theme_frames(stages, out, smooth=smooth)
     print(f"[{theme}] {len(stages)}단계 -> {N_OUT}프레임(크로스페이드) 저장: {out}")
 

--- a/install_mac.command
+++ b/install_mac.command
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e
 cd "$(dirname "$0")"
+SRC="$(pwd)"
+
+LABEL="com.memorycat.desktop"
+# 테스트에서 설치 위치를 갈아끼울 수 있게 열어 둔 구멍. 평소엔 ~/Applications.
+APPS_DIR="${MEMORY_CAT_APPS_DIR:-$HOME/Applications}"
+APP="$APPS_DIR/Memory Cat.app"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG="$HOME/Library/Logs/Memory Cat/cat.log"
+
 echo "🐱 메모리 뚱냥이 설치 중..."
 
 # 개발자 도구가 없는 Mac 에서 /usr/bin/python3 는 실제 인터프리터가 아니라
@@ -18,33 +27,69 @@ if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)' 2
     exit 1
 fi
 
-python3 -m venv .venv
-./.venv/bin/python -m pip install -q --upgrade pip
-./.venv/bin/python -m pip install -q -r requirements.txt
-
-PY="$(pwd)/.venv/bin/python"
-APP="$(pwd)/desktop_cat.py"
-LABEL="com.memorycat.desktop"
-PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
-mkdir -p "$HOME/Library/LaunchAgents"
-
-cat > "$PLIST" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key><string>$LABEL</string>
-    <key>ProgramArguments</key>
-    <array><string>$PY</string><string>$APP</string></array>
-    <key>WorkingDirectory</key><string>$(pwd)</string>
-    <key>RunAtLoad</key><true/>
-    <key>StandardOutPath</key><string>$(pwd)/cat.log</string>
-    <key>StandardErrorPath</key><string>$(pwd)/cat.log</string>
-</dict>
-</plist>
-EOF
-
+# 앱을 통째로 다시 만드니까, 돌고 있으면 먼저 내린다.
 launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
-launchctl bootstrap "gui/$(id -u)" "$PLIST"
-echo "✅ 완료! 화면 어딘가에 고양이가 떴어요. 드래그로 옮기고 우클릭해보세요."
-echo "   제거하려면 uninstall_mac.command 를 실행하세요."
+
+case "$APP" in
+    *.app) ;;
+    *)
+        echo "❌ 설치 경로가 .app 으로 끝나지 않습니다: $APP"
+        exit 1
+        ;;
+esac
+rm -rf "$APP"
+mkdir -p "$APPS_DIR" "$APP/Contents/Resources"
+
+# 가상환경은 번들 안에 둔다. 앱 하나만 지우면 런타임까지 같이 사라진다.
+python3 -m venv "$APP/Contents/Resources/venv"
+VENVPY="$APP/Contents/Resources/venv/bin/python"
+
+# 이 순서는 바꾸면 안 된다. macOS 기본 python3 의 venv 에 딸려오는 pip 21.2.4 는
+# pyobjc-core 휠을 찾지 못해 소스 빌드로 넘어가고 "Cannot locate a working
+# compiler" 로 죽는다. pip 를 먼저 올려야 휠이 잡힌다.
+"$VENVPY" -m pip install -q --upgrade pip
+"$VENVPY" -m pip install -q -r requirements.txt
+
+# 번들 조립 + LaunchAgent plist 생성. plist 는 plistlib 이 구조적으로 쓴다.
+# (예전처럼 셸 변수를 XML 히어독에 끼워 넣으면 경로에 & 가 있을 때 깨진다.)
+"$VENVPY" "$SRC/macos/build_app.py" \
+    --source "$SRC" \
+    --app "$APP" \
+    --launch-agent "$PLIST" \
+    --log "$LOG"
+
+if ! plutil -lint "$APP/Contents/Info.plist" >/dev/null; then
+    echo "❌ 번들 Info.plist 가 깨졌습니다. 설치를 멈춥니다."
+    exit 1
+fi
+if ! plutil -lint "$PLIST" >/dev/null; then
+    echo "❌ LaunchAgent plist 가 깨졌습니다. 설치를 멈춥니다."
+    exit 1
+fi
+
+if launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/tmp/memorycat-bootstrap.$$; then
+    rm -f "/tmp/memorycat-bootstrap.$$"
+    echo "✅ 완료! 화면 어딘가에 고양이가 떴어요. 드래그로 옮기고 우클릭해보세요."
+else
+    # 여기서 조용히 죽으면 사용자는 설치가 됐는지조차 알 수 없다.
+    # macOS 13+ 의 백그라운드 항목 승인 대기(Bootstrap failed: 5)가 흔한 원인.
+    echo ""
+    echo "⚠️  앱은 설치했지만 로그인 자동 실행 등록에 실패했습니다."
+    echo "    이유:"
+    sed 's/^/      /' "/tmp/memorycat-bootstrap.$$" 2>/dev/null || true
+    rm -f "/tmp/memorycat-bootstrap.$$"
+    echo ""
+    echo "    ▸ 시스템 설정 > 일반 > 로그인 항목에서 'Memory Cat' 을 허용한 뒤"
+    echo "      이 설치 파일을 다시 실행해 보세요."
+    echo "    ▸ 지금 바로 실행하려면:"
+    echo "        open -a \"$APP\""
+    echo ""
+fi
+
+echo ""
+echo "   앱:          $APP"
+echo "   설정·내 테마: $HOME/Library/Application Support/Memory Cat"
+echo "   로그:        $LOG"
+echo "   제거:        uninstall_mac.command"
+echo "                (저장소를 지웠다면 아래 파일을 실행하세요)"
+echo "                \"$APP/Contents/Resources/uninstall_mac.command\""

--- a/macos/build_app.py
+++ b/macos/build_app.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""저장소를 `Memory Cat.app` 번들로 조립하고 LaunchAgent plist 를 만든다.
+
+py2app / PyInstaller 를 쓰지 않는다. 번들이라는 게 결국 정해진 폴더 구조 +
+`Info.plist` + 실행 파일 하나라서, 그 정도는 표준 라이브러리만으로 만들 수 있다.
+그렇게 하면 무엇이 들어갔는지 눈으로 셀 수 있고, 윈도우 PyInstaller 빌드가 겪는
+코드서명·백신 오탐 문제를 macOS 쪽으로 옮겨오지 않는다.
+
+만들어지는 구조::
+
+    Memory Cat.app/
+      Contents/
+        Info.plist            ← CFBundleIdentifier / LSUIElement
+        MacOS/
+          MemoryCat           ← 셸 런처 (CFBundleExecutable)
+          MemoryCatPython     ← 프레임워크 인터프리터 사본
+        Resources/
+          *.py                ← 앱 소스
+          frames/             ← 기본 테마 4종
+          venv/               ← 설치 스크립트가 미리 만들어 둔 가상환경
+          pythonhome          ← 인터프리터가 붙을 프레임워크 경로
+          uninstall_mac.command
+
+`MacOS/MemoryPython` 이 왜 인터프리터 "사본" 이어야 하냐면: CoreFoundation 은
+dyld 가 알려주는 실행 파일 경로에서 위로 올라가며 `Contents/Info.plist` 를 찾아
+메인 번들을 정한다. 셸 스크립트가 venv 의 python 을 실행하면 실행 파일은
+`Python.framework/.../Python.app/Contents/MacOS/Python` 이 되고, 알림은
+`org.python.python` 이름으로 나간다. 인터프리터가 우리 번들 안에 있어야
+`com.memorycat.desktop` 이 된다. (측정해서 확인함 — README 참고)
+
+이 스크립트는 서브프로세스를 쓰지 않는다. 저장소의 파이썬 소스에는
+`subprocess`/`os.system`/`osascript` 호출이 하나도 없고, 그 성질을 유지한다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import plistlib
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import apppaths  # noqa: E402
+
+EXECUTABLE_NAME = "MemoryCat"
+INTERPRETER_NAME = "MemoryCatPython"
+PYTHON_HOME_FILE = "pythonhome"
+VERSION = "1.0.0"
+
+#: 번들에 들어가는 파이썬 모듈. 글롭 대신 명시해서 무엇이 배포되는지 드러낸다.
+APP_MODULES = (
+    "desktop_cat.py",
+    "apppaths.py",
+    "brain.py",
+    "metrics.py",
+    "i18n.py",
+    "personality.py",
+    "vision_theme.py",
+    "import_theme.py",
+    "generate_frames.py",
+)
+
+EXTRA_RESOURCES = ("uninstall_mac.command", "LICENSE")
+
+# 런처는 경로를 문자열로 끼워 넣지 않는다. 자기 위치에서 전부 역산한다.
+# 그래서 설치 경로에 `&`, 공백, 따옴표가 있어도 이 파일은 그대로다.
+LAUNCHER = """\
+#!/bin/bash
+# Memory Cat 번들 런처. 경로는 전부 자기 위치에서 역산하므로
+# 번들을 통째로 옮겨도 그대로 동작한다.
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RES="$(cd "$HERE/../Resources" && pwd)"
+
+# 가상환경 site-packages 를 PYTHONPATH 로 붙인다. 런처가 실행하는 인터프리터는
+# venv 의 python 이 아니라 번들 안 사본이라서 pyvenv.cfg 를 타지 않는다.
+for candidate in "$RES"/venv/lib/python*/site-packages; do
+    if [ -d "$candidate" ]; then
+        PYTHONPATH="$candidate${PYTHONPATH:+:$PYTHONPATH}"
+    fi
+done
+export PYTHONPATH
+
+# 애플이 배포하는 인터프리터는 프레임워크를
+# @executable_path/../../../../Python3 로 찾는다. 번들 안으로 복사하면 그 상대
+# 경로가 깨지므로, 원래 프레임워크가 있는 폴더를 dyld 검색 경로에 넣어 준다.
+# 바이너리를 고쳐서 애플 서명을 무효화하는 것보다 이쪽이 덜 침습적이다.
+if [ -f "$RES/@@PYTHON_HOME_FILE@@" ]; then
+    PYHOME="$(cat "$RES/@@PYTHON_HOME_FILE@@")"
+    if [ -d "$PYHOME" ]; then
+        export DYLD_LIBRARY_PATH="$PYHOME${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+    fi
+fi
+
+# 번들 안에 __pycache__ 를 만들지 않는다. 설치된 앱은 읽기 전용으로 둔다.
+export PYTHONDONTWRITEBYTECODE=1
+
+exec "$HERE/@@INTERPRETER_NAME@@" "$RES/desktop_cat.py" "$@"
+"""
+
+
+class BuildError(RuntimeError):
+    """번들을 만들 수 없을 때."""
+
+
+def launcher_script() -> str:
+    """런처 셸 스크립트 본문. 치환되는 건 파일 이름뿐, 경로는 없다."""
+    return LAUNCHER.replace("@@PYTHON_HOME_FILE@@", PYTHON_HOME_FILE).replace(
+        "@@INTERPRETER_NAME@@", INTERPRETER_NAME
+    )
+
+
+def info_plist(version: str = VERSION) -> dict:
+    """번들 Info.plist 내용.
+
+    ``LSUIElement`` 는 앱이 이미 호출하는
+    ``setActivationPolicy_(NSApplicationActivationPolicyAccessory)`` 와 같은
+    말이다. Dock 아이콘도 메뉴 막대도 없는 보조 앱이라는 뜻.
+    """
+    return {
+        "CFBundleDevelopmentRegion": "ko",
+        "CFBundleDisplayName": apppaths.APP_NAME,
+        "CFBundleExecutable": EXECUTABLE_NAME,
+        "CFBundleIdentifier": apppaths.BUNDLE_ID,
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundleName": apppaths.APP_NAME,
+        "CFBundlePackageType": "APPL",
+        "CFBundleShortVersionString": version,
+        "CFBundleVersion": version,
+        "LSApplicationCategoryType": "public.app-category.utilities",
+        "LSMinimumSystemVersion": "10.15",
+        # 데스크톱 액세서리다. Dock 에 뜨지 않는다.
+        "LSUIElement": True,
+        "NSHighResolutionCapable": True,
+        "NSHumanReadableCopyright": "MIT License",
+        "NSSupportsAutomaticTermination": False,
+        "NSSupportsSuddenTermination": False,
+    }
+
+
+def launch_agent_plist(executable: Path, log_file: Path, working_dir: Path) -> dict:
+    """LaunchAgent plist 내용.
+
+    XML 을 손으로 쓰지 않는다. :mod:`plistlib` 이 이스케이프를 책임지므로
+    경로에 ``&``, ``<``, ``>``, 따옴표가 있어도 깨지지 않는다.
+    """
+    return {
+        "Label": apppaths.BUNDLE_ID,
+        "ProgramArguments": [str(executable)],
+        "WorkingDirectory": str(working_dir),
+        "RunAtLoad": True,
+        # 비정상 종료일 때만 되살린다. 사용자가 메뉴로 종료하면(정상 종료)
+        # 다시 뜨지 않는다. ThrottleInterval 이 크래시 루프의 회전 속도를 잡는다.
+        "KeepAlive": {"SuccessfulExit": False},
+        "ThrottleInterval": 60,
+        "ProcessType": "Interactive",
+        "StandardOutPath": str(log_file),
+        "StandardErrorPath": str(log_file),
+    }
+
+
+def framework_interpreter(base_prefix=None):
+    """번들 안으로 복사할 인터프리터를 찾는다.
+
+    프레임워크 빌드의 ``bin/python3`` 은 ``Python.app`` 으로 다시 exec 하는
+    껍데기라서 복사해도 소용이 없다. 진짜 인터프리터인
+    ``Resources/Python.app/Contents/MacOS/Python`` 을 찾아야 한다.
+    """
+    base = Path(base_prefix or sys.base_prefix)
+    candidate = base / "Resources" / "Python.app" / "Contents" / "MacOS" / "Python"
+    if candidate.is_file():
+        return candidate
+    return None
+
+
+def _copy_executable(source: Path, target: Path) -> None:
+    shutil.copy2(source, target)
+    target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _write_executable(target: Path, text: str) -> None:
+    target.write_text(text, encoding="utf-8")
+    target.chmod(0o755)
+
+
+def migrate_user_data(source: Path, user_home: Path) -> dict:
+    """저장소 폴더에 있던 사용자 데이터를 Application Support 로 옮겨 심는다.
+
+    **복사만 한다. 원본은 건드리지 않는다.** 옮기다 실패해서 커스텀 테마가
+    사라지는 상황을 만들지 않기 위해서다. 목적지에 같은 이름이 이미 있으면
+    덮어쓰지 않고 건너뛴다.
+    """
+    moved = {"config": False, "dotenv": False, "themes": []}
+    user_home.mkdir(parents=True, exist_ok=True)
+
+    for name, key in (("config.json", "config"), (".env", "dotenv")):
+        origin = source / name
+        target = user_home / name
+        if origin.is_file() and not origin.is_symlink() and not target.exists():
+            shutil.copy2(origin, target)
+            moved[key] = True
+
+    frames = source / "frames"
+    if frames.is_dir():
+        user_frames = user_home / "frames"
+        for entry in sorted(frames.iterdir()):
+            if not entry.is_dir() or entry.is_symlink():
+                continue
+            if entry.name in apppaths.BUNDLED_THEMES or entry.name.startswith("."):
+                continue
+            if not (entry / "cat_00.png").is_file():
+                continue
+            target = user_frames / entry.name
+            if target.exists():
+                continue
+            user_frames.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(entry, target)
+            moved["themes"].append(entry.name)
+    return moved
+
+
+def assemble(source: Path, app: Path, interpreter=None) -> dict:
+    """번들 뼈대를 채운다. ``Contents/Resources/venv`` 는 이미 있다고 가정한다."""
+    if not (source / "desktop_cat.py").is_file():
+        raise BuildError(f"소스 폴더가 아닙니다: {source}")
+
+    contents = app / "Contents"
+    macos = contents / "MacOS"
+    resources = contents / "Resources"
+    macos.mkdir(parents=True, exist_ok=True)
+    resources.mkdir(parents=True, exist_ok=True)
+
+    for name in APP_MODULES:
+        origin = source / name
+        if not origin.is_file():
+            raise BuildError(f"번들에 넣을 파일이 없습니다: {origin}")
+        shutil.copy2(origin, resources / name)
+
+    for name in EXTRA_RESOURCES:
+        origin = source / name
+        if origin.is_file():
+            shutil.copy2(origin, resources / name)
+    uninstaller = resources / "uninstall_mac.command"
+    if uninstaller.is_file():
+        uninstaller.chmod(0o755)
+
+    frames = resources / "frames"
+    for theme in apppaths.BUNDLED_THEMES:
+        origin = source / "frames" / theme
+        if not origin.is_dir():
+            raise BuildError(f"기본 테마가 없습니다: {origin}")
+        target = frames / theme
+        if target.exists():
+            shutil.rmtree(target)
+        frames.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(origin, target)
+
+    with open(contents / "Info.plist", "wb") as handle:
+        plistlib.dump(info_plist(), handle)
+
+    _write_executable(macos / EXECUTABLE_NAME, launcher_script())
+
+    interpreter = interpreter or framework_interpreter()
+    warnings = []
+    if interpreter is None:
+        # 프레임워크 빌드가 아니면 번들 정체성을 줄 방법이 없다. 앱은 돌지만
+        # 알림은 여전히 "Python" 이름으로 나간다. 조용히 넘기지 않고 알린다.
+        interpreter = Path(getattr(sys, "_base_executable", None) or sys.executable)
+        warnings.append(
+            "프레임워크 인터프리터(Python.app)를 찾지 못했습니다. "
+            "앱은 동작하지만 알림이 'Python' 이름으로 표시될 수 있습니다."
+        )
+    _copy_executable(Path(interpreter), macos / INTERPRETER_NAME)
+    (resources / PYTHON_HOME_FILE).write_text(sys.base_prefix, encoding="utf-8")
+
+    return {"warnings": warnings, "interpreter": str(interpreter)}
+
+
+def write_launch_agent(app: Path, plist_path: Path, log_file: Path,
+                       working_dir: Path) -> None:
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    payload = launch_agent_plist(
+        app / "Contents" / "MacOS" / EXECUTABLE_NAME, log_file, working_dir
+    )
+    with open(plist_path, "wb") as handle:
+        plistlib.dump(payload, handle)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Memory Cat .app 번들 조립")
+    parser.add_argument("--source", required=True, help="저장소 폴더")
+    parser.add_argument("--app", required=True, help="만들 .app 경로")
+    parser.add_argument("--launch-agent", help="LaunchAgent plist 경로")
+    parser.add_argument("--log", help="앱 로그 파일 경로")
+    parser.add_argument(
+        "--skip-migration", action="store_true", help="사용자 데이터 이전 생략"
+    )
+    args = parser.parse_args(argv)
+
+    source = Path(args.source).expanduser().resolve()
+    app = Path(args.app).expanduser()
+
+    result = assemble(source, app)
+    for warning in result["warnings"]:
+        print(f"⚠️  {warning}")
+
+    if not args.skip_migration:
+        moved = migrate_user_data(source, apppaths.ensure_user_data_dir())
+        if moved["config"]:
+            print("   설정을 사용자 폴더로 옮겼습니다: config.json")
+        if moved["dotenv"]:
+            print("   API 키 파일을 사용자 폴더로 옮겼습니다: .env")
+        for name in moved["themes"]:
+            print(f"   직접 만든 테마를 사용자 폴더로 옮겼습니다: {name}")
+
+    log_file = Path(args.log).expanduser() if args.log else apppaths.log_dir() / "cat.log"
+    if args.launch_agent:
+        plist_path = Path(args.launch_agent).expanduser()
+    else:
+        plist_path = (
+            Path.home() / "Library" / "LaunchAgents" / f"{apppaths.BUNDLE_ID}.plist"
+        )
+    write_launch_agent(app, plist_path, log_file, Path.home())
+    print(f"   LaunchAgent: {plist_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -143,6 +143,83 @@ class DesktopCatTests(unittest.TestCase):
                 desktop_cat.next_pet_theme_name(frames_dir), "mypet3"
             )
 
+    def test_next_pet_theme_name_avoids_names_taken_in_either_root(self):
+        # 번들에 mypet 이 있는데 사용자 폴더가 비었다고 mypet 을 다시 쓰면
+        # 기본 테마를 가려 버린다. 두 폴더를 모두 봐야 한다.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bundled = Path(temp_dir) / "bundled"
+            user = Path(temp_dir) / "user"
+            bundled.mkdir()
+            user.mkdir()
+            (bundled / "mypet").mkdir()
+            with (
+                patch.object(desktop_cat, "FRAMES_BASE", str(bundled)),
+                patch.object(desktop_cat, "USER_FRAMES_BASE", str(user)),
+            ):
+                self.assertEqual(desktop_cat.next_pet_theme_name(), "mypet2")
+
+    def test_discover_themes_merges_bundled_and_user_folders(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bundled = Path(temp_dir) / "bundled"
+            user = Path(temp_dir) / "user"
+            for root, names in ((bundled, ("cute", "simple")), (user, ("mypet3",))):
+                for name in names:
+                    theme = root / name
+                    theme.mkdir(parents=True)
+                    (theme / "cat_00.png").write_bytes(b"png")
+            with (
+                patch.object(desktop_cat, "FRAMES_BASE", str(bundled)),
+                patch.object(desktop_cat, "USER_FRAMES_BASE", str(user)),
+            ):
+                self.assertEqual(
+                    desktop_cat.discover_themes(), ["cute", "simple", "mypet3"]
+                )
+
+    def test_discover_themes_lists_a_shadowing_user_theme_only_once(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bundled = Path(temp_dir) / "bundled"
+            user = Path(temp_dir) / "user"
+            for root in (bundled, user):
+                theme = root / "cute"
+                theme.mkdir(parents=True)
+                (theme / "cat_00.png").write_bytes(b"png")
+            with (
+                patch.object(desktop_cat, "FRAMES_BASE", str(bundled)),
+                patch.object(desktop_cat, "USER_FRAMES_BASE", str(user)),
+            ):
+                self.assertEqual(desktop_cat.discover_themes(), ["cute"])
+                # 같은 이름이면 사용자가 만든 쪽을 쓴다.
+                self.assertEqual(
+                    desktop_cat.frame_path("cute", 0),
+                    str(user / "cute" / "cat_00.png"),
+                )
+
+    def test_frame_path_reads_a_user_theme_from_the_user_folder(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bundled = Path(temp_dir) / "bundled"
+            user = Path(temp_dir) / "user"
+            bundled.mkdir()
+            theme = user / "mypet3"
+            theme.mkdir(parents=True)
+            for index in range(3):
+                (theme / f"cat_{index:02d}.png").write_bytes(b"png")
+            with (
+                patch.object(desktop_cat, "FRAMES_BASE", str(bundled)),
+                patch.object(desktop_cat, "USER_FRAMES_BASE", str(user)),
+            ):
+                self.assertEqual(desktop_cat.frame_count("mypet3"), 3)
+                self.assertEqual(
+                    desktop_cat.frame_path("mypet3", 9),
+                    str(theme / "cat_02.png"),
+                )
+
+    def test_save_config_creates_the_user_data_folder(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "Application Support" / "Memory Cat" / "config.json"
+            self.assertTrue(desktop_cat.save_config({"theme": "cute"}, str(target)))
+            self.assertEqual(json.loads(target.read_text(encoding="utf-8")),
+                             {"theme": "cute"})
+
     def test_pet_theme_worker_returns_build_result_on_main_queue(self):
         callback = Mock()
         queue = Mock()

--- a/tests/test_macos_bundle.py
+++ b/tests/test_macos_bundle.py
@@ -1,0 +1,301 @@
+"""`.app` 번들 조립과 LaunchAgent plist 생성에 대한 회귀 테스트.
+
+여기서 지키려는 것 두 가지.
+
+1. plist 를 문자열로 조립하지 않는다. 경로에 ``&``/``<``/``>`` 가 있어도
+   깨지지 않아야 한다. (예전 히어독 방식은 `Memory & Cat` 폴더에서
+   "Encountered unknown ampersand-escape sequence" 로 죽었다.)
+2. 사용자가 만든 테마는 번들로 옮겨가는 과정에서 사라지지 않는다.
+"""
+
+import importlib.util
+import os
+import plistlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import apppaths
+
+_BUILD_APP = Path(__file__).resolve().parent.parent / "macos" / "build_app.py"
+_spec = importlib.util.spec_from_file_location("build_app", _BUILD_APP)
+build_app = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build_app)
+
+# XML 로 그냥 끼워 넣으면 반드시 깨지는 문자들.
+NASTY = 'Memory & Cat <v1> "quoted"'
+
+
+class LaunchAgentPlistTests(unittest.TestCase):
+    def test_special_characters_in_paths_round_trip(self):
+        app = Path("/Users/me") / NASTY / "Memory Cat.app"
+        log = Path("/Users/me") / NASTY / "cat.log"
+        payload = build_app.launch_agent_plist(
+            app / "Contents" / "MacOS" / "MemoryCat", log, Path("/Users/me") / NASTY
+        )
+
+        # plistlib 으로 쓰고 다시 읽었을 때 원래 경로 그대로여야 한다.
+        blob = plistlib.dumps(payload)
+        parsed = plistlib.loads(blob)
+
+        self.assertEqual(
+            parsed["ProgramArguments"][0],
+            str(app / "Contents" / "MacOS" / "MemoryCat"),
+        )
+        self.assertEqual(parsed["StandardOutPath"], str(log))
+        self.assertEqual(parsed["StandardErrorPath"], str(log))
+        self.assertEqual(parsed["WorkingDirectory"], str(Path("/Users/me") / NASTY))
+        # 원문 '&' 가 그대로 새어 나가면 XML 이 깨진 것이다.
+        self.assertIn(b"&amp;", blob)
+        self.assertNotIn(b"Cat & ", blob)
+
+    def test_label_matches_bundle_identifier(self):
+        payload = build_app.launch_agent_plist(
+            Path("/a/MemoryCat"), Path("/a/cat.log"), Path("/a")
+        )
+        self.assertEqual(payload["Label"], apppaths.BUNDLE_ID)
+
+    def test_keep_alive_only_restarts_after_abnormal_exit(self):
+        payload = build_app.launch_agent_plist(
+            Path("/a/MemoryCat"), Path("/a/cat.log"), Path("/a")
+        )
+        # 사용자가 메뉴에서 종료하면(정상 종료) 되살아나면 안 된다.
+        self.assertEqual(payload["KeepAlive"], {"SuccessfulExit": False})
+        # 크래시 루프가 CPU 를 태우지 않게 간격을 둔다.
+        self.assertGreaterEqual(payload["ThrottleInterval"], 10)
+
+    def test_written_plist_parses_from_disk(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp) / NASTY
+            plist_path = root / "com.memorycat.desktop.plist"
+            build_app.write_launch_agent(
+                root / "Memory Cat.app", plist_path, root / "cat.log", root
+            )
+            with open(plist_path, "rb") as handle:
+                parsed = plistlib.load(handle)
+            self.assertTrue(
+                parsed["ProgramArguments"][0].endswith(
+                    "Memory Cat.app/Contents/MacOS/MemoryCat"
+                )
+            )
+
+
+class InfoPlistTests(unittest.TestCase):
+    def test_carries_identity_and_accessory_flag(self):
+        info = build_app.info_plist()
+        self.assertEqual(info["CFBundleIdentifier"], apppaths.BUNDLE_ID)
+        self.assertEqual(info["CFBundleName"], apppaths.APP_NAME)
+        self.assertEqual(info["CFBundleExecutable"], build_app.EXECUTABLE_NAME)
+        self.assertEqual(info["CFBundlePackageType"], "APPL")
+        # 앱이 NSApplicationActivationPolicyAccessory 를 쓴다. 번들도 같은 말을
+        # 해야 Dock 아이콘이 잠깐 튀어나오지 않는다.
+        self.assertIs(info["LSUIElement"], True)
+
+    def test_round_trips_through_plistlib(self):
+        parsed = plistlib.loads(plistlib.dumps(build_app.info_plist()))
+        self.assertEqual(parsed["CFBundleIdentifier"], apppaths.BUNDLE_ID)
+
+
+class LauncherScriptTests(unittest.TestCase):
+    def test_no_placeholder_survives(self):
+        script = build_app.launcher_script()
+        self.assertNotIn("@@", script)
+        self.assertIn(build_app.INTERPRETER_NAME, script)
+        self.assertIn(build_app.PYTHON_HOME_FILE, script)
+
+    def test_resolves_paths_from_its_own_location(self):
+        # 설치 경로를 스크립트에 박아 넣으면 번들을 옮기는 순간 깨진다.
+        script = build_app.launcher_script()
+        self.assertIn('HERE="$(cd "$(dirname "$0")" && pwd)"', script)
+        self.assertNotIn("/Users/", script)
+        self.assertNotIn("$HOME", script)
+
+
+class MigrationTests(unittest.TestCase):
+    def _make_theme(self, root: Path, name: str) -> Path:
+        theme = root / "frames" / name
+        theme.mkdir(parents=True)
+        (theme / "cat_00.png").write_bytes(b"png")
+        return theme
+
+    def test_custom_theme_is_copied_and_original_left_alone(self):
+        with tempfile.TemporaryDirectory() as temp:
+            source = Path(temp) / "repo"
+            source.mkdir()
+            self._make_theme(source, "mypet3")
+            self._make_theme(source, "cute")
+            home = Path(temp) / "support"
+
+            moved = build_app.migrate_user_data(source, home)
+
+            self.assertEqual(moved["themes"], ["mypet3"])
+            self.assertTrue((home / "frames" / "mypet3" / "cat_00.png").is_file())
+            # 기본 테마는 번들에서 오므로 사용자 폴더로 옮기지 않는다.
+            self.assertFalse((home / "frames" / "cute").exists())
+            # 원본은 손대지 않는다. 이전이 실패해도 잃는 게 없어야 한다.
+            self.assertTrue((source / "frames" / "mypet3" / "cat_00.png").is_file())
+
+    def test_config_and_dotenv_move_but_never_overwrite(self):
+        with tempfile.TemporaryDirectory() as temp:
+            source = Path(temp) / "repo"
+            source.mkdir()
+            (source / "config.json").write_text('{"theme": "mypet3"}', encoding="utf-8")
+            (source / ".env").write_text("OPENAI_API_KEY=old\n", encoding="utf-8")
+            home = Path(temp) / "support"
+            home.mkdir()
+            (home / ".env").write_text("OPENAI_API_KEY=already-here\n", encoding="utf-8")
+
+            moved = build_app.migrate_user_data(source, home)
+
+            self.assertTrue(moved["config"])
+            self.assertFalse(moved["dotenv"])
+            self.assertEqual(
+                (home / "config.json").read_text(encoding="utf-8"),
+                '{"theme": "mypet3"}',
+            )
+            self.assertEqual(
+                (home / ".env").read_text(encoding="utf-8"),
+                "OPENAI_API_KEY=already-here\n",
+            )
+
+    def test_existing_user_theme_is_never_clobbered(self):
+        with tempfile.TemporaryDirectory() as temp:
+            source = Path(temp) / "repo"
+            source.mkdir()
+            self._make_theme(source, "mypet3")
+            home = Path(temp) / "support"
+            keep = home / "frames" / "mypet3"
+            keep.mkdir(parents=True)
+            (keep / "cat_00.png").write_bytes(b"newer")
+
+            moved = build_app.migrate_user_data(source, home)
+
+            self.assertEqual(moved["themes"], [])
+            self.assertEqual((keep / "cat_00.png").read_bytes(), b"newer")
+
+    def test_symlinked_theme_is_ignored(self):
+        with tempfile.TemporaryDirectory() as temp:
+            source = Path(temp) / "repo"
+            (source / "frames").mkdir(parents=True)
+            outside = Path(temp) / "outside"
+            outside.mkdir()
+            (outside / "cat_00.png").write_bytes(b"png")
+            os.symlink(outside, source / "frames" / "sneaky")
+            home = Path(temp) / "support"
+
+            moved = build_app.migrate_user_data(source, home)
+
+            self.assertEqual(moved["themes"], [])
+
+
+class AssembleTests(unittest.TestCase):
+    def _fake_source(self, root: Path) -> Path:
+        source = root / "repo"
+        source.mkdir()
+        for name in build_app.APP_MODULES:
+            (source / name).write_text("# stub\n", encoding="utf-8")
+        for theme in apppaths.BUNDLED_THEMES:
+            theme_dir = source / "frames" / theme
+            theme_dir.mkdir(parents=True)
+            (theme_dir / "cat_00.png").write_bytes(b"png")
+        (source / "uninstall_mac.command").write_text("#!/bin/bash\n", encoding="utf-8")
+        return source
+
+    def test_layout_and_permissions(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source = self._fake_source(root)
+            interpreter = root / "FakePython"
+            interpreter.write_bytes(b"\xcf\xfa\xed\xfe")
+            app = root / NASTY / "Memory Cat.app"
+
+            build_app.assemble(source, app, interpreter=interpreter)
+
+            contents = app / "Contents"
+            launcher = contents / "MacOS" / build_app.EXECUTABLE_NAME
+            copied = contents / "MacOS" / build_app.INTERPRETER_NAME
+            self.assertTrue(launcher.is_file())
+            self.assertTrue(os.access(launcher, os.X_OK))
+            # 인터프리터가 번들 안에 있어야 CoreFoundation 이 우리 Info.plist 를
+            # 메인 번들로 잡는다. 없으면 알림이 "Python" 이름으로 나간다.
+            self.assertTrue(copied.is_file())
+            self.assertTrue(os.access(copied, os.X_OK))
+
+            with open(contents / "Info.plist", "rb") as handle:
+                info = plistlib.load(handle)
+            self.assertEqual(info["CFBundleIdentifier"], apppaths.BUNDLE_ID)
+
+            resources = contents / "Resources"
+            for name in build_app.APP_MODULES:
+                self.assertTrue((resources / name).is_file(), name)
+            for theme in apppaths.BUNDLED_THEMES:
+                self.assertTrue((resources / "frames" / theme / "cat_00.png").is_file())
+            # 저장소가 사라져도 제거할 수 있게 언인스톨러를 함께 넣는다.
+            uninstaller = resources / "uninstall_mac.command"
+            self.assertTrue(uninstaller.is_file())
+            self.assertTrue(os.access(uninstaller, os.X_OK))
+
+    def test_missing_default_theme_is_reported(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source = self._fake_source(root)
+            import shutil
+
+            shutil.rmtree(source / "frames" / "derpy")
+            interpreter = root / "FakePython"
+            interpreter.write_bytes(b"\xcf\xfa\xed\xfe")
+
+            with self.assertRaises(build_app.BuildError):
+                build_app.assemble(source, root / "app.app", interpreter=interpreter)
+
+    def test_framework_interpreter_returns_none_when_absent(self):
+        with tempfile.TemporaryDirectory() as temp:
+            self.assertIsNone(build_app.framework_interpreter(temp))
+
+    def test_framework_interpreter_finds_python_app(self):
+        with tempfile.TemporaryDirectory() as temp:
+            target = (
+                Path(temp) / "Resources" / "Python.app" / "Contents" / "MacOS"
+            )
+            target.mkdir(parents=True)
+            (target / "Python").write_bytes(b"\xcf\xfa\xed\xfe")
+            self.assertEqual(
+                build_app.framework_interpreter(temp), target / "Python"
+            )
+
+
+class AppPathsTests(unittest.TestCase):
+    def test_home_override_moves_every_user_path(self):
+        with tempfile.TemporaryDirectory() as temp:
+            with patch.dict(os.environ, {apppaths.HOME_ENV: temp}, clear=False):
+                self.assertEqual(apppaths.user_data_dir(), Path(temp))
+                self.assertEqual(apppaths.user_frames_dir(), Path(temp) / "frames")
+                self.assertEqual(apppaths.config_file(), Path(temp) / "config.json")
+
+    def test_user_theme_wins_over_bundled_theme_of_the_same_name(self):
+        with tempfile.TemporaryDirectory() as temp:
+            user = Path(temp) / "support"
+            (user / "frames" / "cute").mkdir(parents=True)
+            with patch.dict(os.environ, {apppaths.HOME_ENV: str(user)}, clear=False):
+                self.assertEqual(
+                    apppaths.theme_dir("cute"), user / "frames" / "cute"
+                )
+
+    def test_unknown_theme_falls_back_to_the_user_folder(self):
+        with tempfile.TemporaryDirectory() as temp:
+            with patch.dict(os.environ, {apppaths.HOME_ENV: temp}, clear=False):
+                self.assertEqual(
+                    apppaths.theme_dir("nope"), Path(temp) / "frames" / "nope"
+                )
+
+    def test_dotenv_is_looked_up_in_user_data_first(self):
+        with tempfile.TemporaryDirectory() as temp:
+            with patch.dict(os.environ, {apppaths.HOME_ENV: temp}, clear=False):
+                candidates = apppaths.dotenv_candidates()
+            self.assertEqual(candidates[0], Path(temp) / ".env")
+            self.assertEqual(candidates[1], apppaths.source_dir() / ".env")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uninstall_mac.command
+++ b/uninstall_mac.command
@@ -1,5 +1,31 @@
 #!/bin/bash
+# 이 파일은 저장소와 설치된 앱 번들(Contents/Resources/) 양쪽에 있다.
+# 저장소를 지워도 앱 안의 사본으로 제거할 수 있다.
 LABEL="com.memorycat.desktop"
+APPS_DIR="${MEMORY_CAT_APPS_DIR:-$HOME/Applications}"
+APP="$APPS_DIR/Memory Cat.app"
+DATA="$HOME/Library/Application Support/Memory Cat"
+LOGS="$HOME/Library/Logs/Memory Cat"
+
 launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
 rm -f "$HOME/Library/LaunchAgents/$LABEL.plist"
-echo "🐱 메모리 뚱냥이 제거 완료. (폴더는 그대로 남아있어요)"
+
+case "$APP" in
+    *.app)
+        if [ -d "$APP" ]; then
+            rm -rf "$APP"
+        fi
+        ;;
+    *)
+        echo "⚠️  앱 경로가 이상해서 지우지 않았습니다: $APP"
+        ;;
+esac
+
+rm -rf "$LOGS"
+
+echo "🐱 메모리 뚱냥이 제거 완료."
+echo ""
+echo "   설정과 직접 만든 테마는 남겨 뒀어요:"
+echo "       $DATA"
+echo "   그것까지 지우려면:"
+echo "       rm -rf \"$DATA\""

--- a/vision_theme.py
+++ b/vision_theme.py
@@ -18,6 +18,7 @@ from dotenv import load_dotenv
 from openai import OpenAI
 from PIL import Image
 
+import apppaths
 from import_theme import cut_background, fit_square, save_theme_frames, segments
 
 
@@ -25,7 +26,9 @@ MODEL = "gpt-image-2"
 IMAGE_SIZE = "1536x1024"
 DEFAULT_QUALITY = "medium"
 QUALITY_CHOICES = ("low", "medium", "high")
-FRAMES_DIR = Path(__file__).with_name("frames")
+# 새로 만든 테마는 언제나 사용자 폴더에 쌓인다. 설치된 앱 번들 안은 건드리지
+# 않는다(다시 설치하면 지워지고, 나중에 코드서명을 하면 쓸 수도 없다).
+FRAMES_DIR = apppaths.user_frames_dir()
 # 이미지 API 가 직접 받는 포맷. HEIC 는 여기 없어서 변환이 필요하다.
 API_IMAGE_FORMATS = frozenset({"PNG", "JPEG", "WEBP"})
 MIN_DETECTED_STAGES = 6
@@ -162,11 +165,13 @@ def generate_sheet(photo_path, retry_prompt=False) -> Image.Image:
     if not photo.is_file():
         raise ThemeGenerationError(f"Pet photo not found: {photo}")
 
-    load_dotenv(Path(__file__).with_name(".env"), override=False)
+    for candidate in apppaths.dotenv_candidates():
+        load_dotenv(candidate, override=False)
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise ThemeGenerationError(
-            "OPENAI_API_KEY is missing; add it to the project's .env file."
+            "OPENAI_API_KEY is missing; add it to "
+            f"{apppaths.user_data_dir() / '.env'}."
         )
 
     prompt = SHEET_PROMPT


### PR DESCRIPTION
Three P1 defects from the review all trace back to one root cause: the app was a loose Python script run by a LaunchAgent rather than a real application. This makes it one.

| Defect | Why the bundle fixes it |
|---|---|
| Install welded to the repo folder — move or delete the clone and the app breaks at next login, leaving an orphaned LaunchAgent | The app lives in `~/Applications/Memory Cat.app` with its own interpreter and venv; the uninstaller ships inside the bundle |
| `$(pwd)` interpolated into a plist heredoc — a path containing `&` produces malformed XML | The plist is built with `plistlib`, structurally |
| Notifications attributed to "Python" | The bundle carries `CFBundleIdentifier = com.memorycat.desktop` |

## The notification identity was harder than expected

Making a bundle is not sufficient on its own. Three variants were measured and only the last one worked: a shell launcher that `exec`s the venv python still reports `org.python.python`, and so does copying `bin/python3` into the bundle — because on a framework build `bin/python3` is a shim that re-execs `Python.app`, and CoreFoundation resolves bundle identity from the path dyld reports. The real interpreter has to live inside the bundle.

That exposes a second problem specific to the floor we support: the stock macOS 3.9 interpreter is linked with `@executable_path/../../../../Python3`, so copying it breaks dyld. Two fixes work — rewriting the load command with `install_name_tool` plus an ad-hoc re-sign, or adding the framework directory to `DYLD_LIBRARY_PATH` in the launcher. **The launcher approach was chosen deliberately**: replacing Apple's signature with an ad-hoc one weakens a property this codebase has been careful about, and a missed re-sign kills the binary silently.

## Where user data lives now

`config.json`, `.env`, and generated pet themes move to `~/Library/Application Support/Memory Cat/`; logs to `~/Library/Logs/Memory Cat/`. Bundled themes stay in the bundle, and theme discovery merges both roots with user themes winning on a name clash.

Existing installs are migrated on first run by **copying, not moving**, skipping anything already present at the destination and ignoring symlinks — so a failed migration cannot cost someone the custom themes they paid an image API to generate.

`.env` was not in the original scope but had to move too: without it a bundled app cannot reach the API key at all, and both AI features would have failed silently.

## Verification on stock Python 3.9

3.9 matters because that is what `python3` resolves to on a stock Mac and what the installer uses. The full lifecycle was run end to end under an isolated `HOME` containing an `&`, with `launchctl` stubbed so no real LaunchAgent was touched:

```
bundleIdentifier : com.memorycat.desktop
CFBundleName     : Memory Cat
LSUIElement      : True
python           : 3.9.6
themes           : ['cute','simple','madness','derpy','dog-hero','gandi-v2'] ...
config           : .../Library/Application Support/Memory Cat/config.json
```

The old bug reproduces on the previous code (`Encountered unknown ampersand-escape sequence`) and the new plists pass `plutil -lint` with `&` round-tripping intact. After deleting the source repo the app still runs, the in-bundle uninstaller still removes the app and LaunchAgent, and custom themes and config survive.

**106 passed, 2 skipped** (was 81); 25 new tests including `macos/build_app.py` coverage.

## Also folded in

`launchctl bootstrap` failures are now reported instead of exiting silently under `set -e`; `KeepAlive` is `{SuccessfulExit: false}` with `ThrottleInterval: 60`, so quitting from the menu stays quit while a crash loop is throttled; and the README privacy section's `cat.log` sentence was corrected — it said "beside the app", which this change would have turned into a false statement that no merge conflict would have caught.

## Not verified

Real `launchctl bootstrap` was stubbed, so login-time autostart and the macOS 13+ background-item approval flow remain untested. The notification banner's displayed name was not visually confirmed — `lsappinfo` reporting `com.memorycat.desktop` is as far as the evidence goes. No `.icns` icon yet, and there is no single-instance guard, so a Finder double-click alongside the LaunchAgent could show two cats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)