### PR TITLE
Do not claim the cat appeared when it did not

### DIFF
--- a/install_mac.command
+++ b/install_mac.command
@@ -79,7 +79,42 @@ fi
 
 if launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/tmp/memorycat-bootstrap.$$; then
     rm -f "/tmp/memorycat-bootstrap.$$"
-    echo "✅ 완료! 화면 어딘가에 고양이가 떴어요. 드래그로 옮기고 우클릭해보세요."
+
+    # bootstrap 이 성공해도 launchd 가 RunAtLoad 를 무시하는 경우가 있다.
+    # 그때 "떴어요" 라고 말하면 사용자는 뜨지도 않은 고양이를 찾게 되므로,
+    # 실제로 떴는지 보고 안 떴으면 한 번 밀어 준다.
+    started=""
+    for _ in 1 2 3 4 5 6; do
+        if launchctl print "gui/$(id -u)/$LABEL" 2>/dev/null | grep -q "state = running"; then
+            started="yes"
+            break
+        fi
+        sleep 0.5
+    done
+
+    if [ -z "$started" ]; then
+        launchctl kickstart "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || true
+        for _ in 1 2 3 4 5 6; do
+            if launchctl print "gui/$(id -u)/$LABEL" 2>/dev/null | grep -q "state = running"; then
+                started="yes"
+                break
+            fi
+            sleep 0.5
+        done
+    fi
+
+    if [ -n "$started" ]; then
+        echo "✅ 완료! 화면 어딘가에 고양이가 떴어요. 드래그로 옮기고 우클릭해보세요."
+    else
+        echo ""
+        echo "⚠️  앱은 설치했는데 고양이가 아직 안 떴어요."
+        echo "    ▸ 지금 바로 보려면:"
+        echo "        open -a \"$APP\""
+        echo "    ▸ 로그인할 때 자동으로 뜨게 하려면 시스템 설정 >"
+        echo "      일반 > 로그인 항목 및 확장 프로그램에서 'Memory Cat' 을 켜 주세요."
+        echo "    ▸ 그래도 안 되면 로그를 봐 주세요: $LOG"
+        echo ""
+    fi
 else
     # 여기서 조용히 죽으면 사용자는 설치가 됐는지조차 알 수 없다.
     # macOS 13+ 의 백그라운드 항목 승인 대기(Bootstrap failed: 5)가 흔한 원인.


### PR DESCRIPTION
Found by installing on a real Mac — every isolated test had missed it, because they all stubbed `launchctl`.

## What happens

`launchctl bootstrap` returns 0. The plist is correct (`RunAtLoad => 1`). launchd even reports `properties = runatload`. And then it never starts the job:

```
state = not running
last exit code = (never exited)
properties = runatload | inferred program
```

Meanwhile the installer prints **"✅ 완료! 화면 어딘가에 고양이가 떴어요"** and the user goes looking for a cat that was never launched. `launchctl kickstart` starts it immediately, and the app itself runs fine when executed directly — so nothing was wrong with the bundle. The installer was simply treating "bootstrap returned 0" as proof the app was running.

That assumption was never tested, because every verification up to now replaced `launchctl` with a stub precisely to avoid touching a live machine.

## The fix

After bootstrap, wait for the job to actually reach `state = running`. If it has not, nudge it with `kickstart` and wait again. Only then claim success. If it still has not started, say so plainly and point at Login Items and the log instead of congratulating the user.

The existing `bootstrap`-failed branch is unchanged; this covers the case where bootstrap *succeeds* and nothing happens anyway.

## Verified on the machine that reproduced it

Booting the job out and rerunning the installer now ends with `state = running`, exactly one process, and no false success message.

**133 passed, 2 skipped** — unchanged, this is a shell-script fix.

## Also confirmed by that same real install

Things only a live run could show: the app renders, the alert icon is the cat, the AI diagnosis reaches OpenAI and returns a real answer, config/`.env`/custom themes all migrate to Application Support, opening the app a second time reveals the running cat instead of starting a second one, and a window dragged off-screen comes back.

Still unverified: whether the job starts on its own at login. That needs a logout, and it is the reason this fix matters — an installer that lies about success makes that failure invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)