### PR TITLE
Say when the Windows build was written

### DIFF
--- a/windows/README.txt
+++ b/windows/README.txt
@@ -93,4 +93,5 @@ build_exe.bat 이 만드는 MemoryCat.exe 는 **코드 서명(code signing)이 �
   - 테마 4종        : 귀여운 / 단순한 / 광기 / 경각심
   - 크기 4종        : 작게 / 보통 / 크게 / 왕
 
-만든이: 현희 (+ Claude) 🐾
+만든이: 현희 (+ Claude, Codex) 🐾
+        (Windows 버전은 macOS 앱보다 먼저 만든 별도 구현입니다)


### PR DESCRIPTION
`windows/README.txt` credited "현희 (+ Claude)" while `README.md` says all application code was written by Codex. Read together the two contradicted each other — the kind of small inconsistency a reader notices and quietly distrusts.

The Windows app predates the Codex collaboration: `windows/windows_cat.pyw` was added in the first commit and has not been substantially rewritten since. The note now says that outright, so both documents can be accurate at once, and the credit lists both collaborators for the project as a whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)