### PR TITLE
Keep requirements files ASCII so pip can read them on Korean Windows

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
-# 테스트 전용. 앱 실행에 필요한 패키지는 requirements.txt 에 있음
-# 상한은 다음 메이저 차단용, 하한은 검증된 최소 버전.
-# == 로 박지 않는 이유는 requirements.txt 주석 참고 (Python 3.9 지원).
-# pytest 9 는 3.9 를 지원하지 않으므로 3.9 에서는 pip 가 8.x 로 백트래킹한다.
+# Tests only. Packages needed to run the app are in requirements.txt.
+# Upper bound blocks the next major, lower bound is the oldest verified.
+# See requirements.txt for why nothing is pinned with == (Python 3.9 support)
+# and why this file stays ASCII.
+# pytest 9 does not support 3.9, so pip backtracks to 8.x there.
 pytest>=8,<10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,33 @@
-# 버전 정책: 아래·위 경계를 모두 고정한다.
-#   - 위쪽(<N): 다음 메이저 버전을 차단한다. 이 앱은 install_mac.command 가
-#     LaunchAgent 로 등록해 "매 로그인마다 사용자 권한으로" 실행되므로,
-#     예고 없는 메이저 업그레이드가 로그인 때마다 터지는 앱이 되면 안 된다.
-#   - 아래쪽(>=N): 실제로 검증한 최소 버전.
-#   - 정확한 핀(==)은 쓰지 않는다. macOS 기본 python3 는 3.9.6 이고
-#     install_mac.command 가 바로 그 인터프리터를 쓴다. 개발 환경(3.14)에
-#     깔린 최신 버전들(pyobjc 12.2.1, numpy 2.5.0, pillow 12.2.0)은 3.9 를
-#     지원하지 않으므로, == 로 박으면 기본 맥 사용자 전원이 설치에 실패한다.
-#     범위로 두면 pip 가 3.9 에서는 3.9 를 지원하는 마지막 버전으로
-#     백트래킹한다(pyobjc 11.1 / numpy 2.0.2 / pillow 11.3.0 등).
-#   ※ 3.9 에서 백트래킹이 동작하려면 pip 자체가 최신이어야 한다.
-#     install_mac.command 의 `pip install --upgrade pip` 단계를 지우지 말 것.
+# Version policy: bound both ends.
+#   - Upper (<N) blocks the next major. install_mac.command registers this as
+#     a LaunchAgent, so it runs at every login with the user's privileges;
+#     an unannounced major upgrade must not turn that into a login-time crash.
+#   - Lower (>=N) is the oldest version actually verified.
+#   - No exact pins (==). Stock macOS python3 is 3.9.6 and install_mac.command
+#     uses that interpreter, but the versions in a 3.14 dev venv
+#     (pyobjc 12.2.1, numpy 2.5.0, pillow 12.2.0) do not support 3.9 -- pinning
+#     to them would fail the install for every stock-Mac user. Ranges let pip
+#     backtrack (3.9 resolves pyobjc 11.1 / numpy 2.0.2 / pillow 11.3.0).
+#   NOTE: that backtracking needs a current pip. Do not remove the
+#   `pip install --upgrade pip` step from install_mac.command.
+#
+# Keep this file ASCII: pip decodes requirements files with the system
+# encoding when there is no BOM, so non-ASCII comments break the install on
+# Korean Windows (cp949).
 
-# macOS 앱 실행에 필요 (desktop_cat.py)
+# Required to run the macOS app (desktop_cat.py)
 psutil>=5.9,<8
-# desktop_cat.py 가 AppKit/Foundation 심볼 27개를 이름으로 import 하므로
-# 메이저 업그레이드 한 번에 앱이 통째로 죽을 수 있다. 상한을 반드시 유지할 것.
+# desktop_cat.py imports 27 AppKit/Foundation symbols by name, so one major
+# upgrade can break the whole app. Keep the upper bound.
 pyobjc-framework-Cocoa>=10,<13
 
-# AI 성능 진단 (brain.py)
+# AI performance diagnosis (brain.py)
 openai>=2.46,<3
 pydantic>=2.9,<3
 python-dotenv>=1.2,<2
 
-# 커스텀 펫 테마 생성 (vision_theme.py, import_theme.py)
-# desktop_cat.py가 로드 시 vision_theme을 import하므로 앱 실행에도 필수
+# Custom pet themes (vision_theme.py, import_theme.py).
+# desktop_cat.py imports vision_theme at load time, so these are required to
+# run the app at all.
 Pillow>=10,<13
 numpy>=1.24,<3

--- a/windows/requirements.txt
+++ b/windows/requirements.txt
@@ -1,5 +1,9 @@
-# Windows 버전(windows_cat.pyw) 실행에 필요한 패키지.
-# 상한은 다음 메이저 버전 차단용 — 자동 시작에 등록해 두고 쓰는 앱이라
-# 예고 없는 메이저 업그레이드로 깨지면 안 된다.
+# Packages needed to run the Windows build (windows_cat.pyw).
+# Upper bounds block the next major: this app gets registered to start
+# automatically, so an unannounced major upgrade must not break it.
+#
+# Keep this file ASCII. pip decodes requirements files with the system
+# encoding when there is no BOM, so Korean comments here fail with
+# UnicodeDecodeError (cp949) on a Korean-language Windows install.
 PySide6>=6.5,<7
 psutil>=5.9,<8


### PR DESCRIPTION
Found while building the Windows executable on a Korean Windows machine. The very first install step failed:

```
UnicodeDecodeError: 'cp949' codec can't decode byte 0xec
in position 34: illegal multibyte sequence
```

## Why

pip decodes a requirements file using the system encoding when the file has no BOM. On a Korean-language Windows install that is **cp949**, and the Korean comments that came in with the version bounds are UTF-8 — so pip dies before fetching a single package.

Reproduced against all three files:

```
requirements.txt:         cp949 fails at position 9
requirements-dev.txt:     cp949 fails at position 2
windows/requirements.txt: cp949 fails at position 34   ← the reported error
```

`windows/requirements.txt` is the one people actually run on Windows, but `requirements-dev.txt` would have stopped a Windows contributor from running the tests too. The macOS file is unaffected in practice only because macOS uses UTF-8 — the file itself is just as undecodable.

This blocked **every Korean Windows user** at the first step, with an error that looks like their machine is broken rather than the repo.

## The fix

Comments are now English, and each file records why it has to stay ASCII so this does not come back. The bounds themselves are unchanged — verified byte-for-byte:

```
requirements.txt        : pins identical
requirements-dev.txt    : pins identical
windows/requirements.txt: pins identical
```

All three now decode cleanly as cp949. **133 passed, 2 skipped** — unchanged.

## Workaround for anyone already stuck

```
pip install "PySide6>=6.5,<7" "psutil>=5.9,<8"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)