### PR TITLE
Say where the API key goes when a feature needs one

### DIFF
--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -39,7 +39,7 @@ from Foundation import (
 
 import apppaths
 import metrics as mc
-from brain import diagnose as run_diagnosis, safe_trash
+from brain import _load_api_key, diagnose as run_diagnosis, safe_trash
 from i18n import (
     LANGUAGE_AUTO,
     LANGUAGE_EN,
@@ -292,6 +292,7 @@ def diagnosis_notification_text(result, language=LANGUAGE_KO):
 
 def diagnosis_result_content(result, personality_label, language=LANGUAGE_KO):
     """진단 JSON을 결과창에서 읽기 쉬운 제목·본문·동작으로 바꾼다."""
+    help_text = None
     if result.get("source") == "openai":
         title = tr(
             language,
@@ -313,6 +314,14 @@ def diagnosis_result_content(result, personality_label, language=LANGUAGE_KO):
             "diagnosis_source_fallback",
             reason=tr(language, reason_key),
         )
+        if result.get("fallback_reason") == "missing_api_key":
+            # 키가 없어서 떨어진 경우에만 넣는다. 다른 실패 사유는 사용자가
+            # 할 수 있는 게 없어서 안내가 오히려 방해가 된다.
+            help_text = tr(
+                language,
+                "missing_api_key_help",
+                path=apppaths.user_data_dir() / ".env",
+            )
 
     why = [str(line).strip() for line in result.get("why_slow", []) if str(line).strip()]
     causes = "\n".join(f"• {line}" for line in why) or tr(language, "diagnosis_empty")
@@ -324,6 +333,7 @@ def diagnosis_result_content(result, personality_label, language=LANGUAGE_KO):
         part
         for part in (
             source,
+            help_text,
             causes,
             f"{tr(language, 'diagnosis_advice_heading')}\n{advice}",
             tr(language, "diagnosis_reclaimable", size=reclaimable),
@@ -718,6 +728,12 @@ class CatController(NSObject):
         if getattr(self, "_pet_theme_running", False):
             return
 
+        # 사진을 다 고른 뒤에 "키가 없다"고 하면 헛수고를 시키는 것이다.
+        # 누르자마자 알려 준다.
+        if not _load_api_key():
+            self._show_missing_api_key_alert()
+            return
+
         panel = NSOpenPanel.openPanel()
         panel.setCanChooseFiles_(True)
         panel.setCanChooseDirectories_(False)
@@ -1029,6 +1045,18 @@ class CatController(NSObject):
             return True
         except Exception:
             return False
+
+    @objc.python_method
+    def _show_missing_api_key_alert(self):
+        """키가 없어 AI 기능을 못 쓸 때, 어디에 무엇을 넣으면 되는지 보여 준다."""
+        self._show_information_alert(
+            tr(self.language, "missing_api_key_title"),
+            tr(
+                self.language,
+                "missing_api_key_help",
+                path=apppaths.user_data_dir() / ".env",
+            ),
+        )
 
     @objc.python_method
     def _show_information_alert(self, title, body):

--- a/i18n.py
+++ b/i18n.py
@@ -51,6 +51,15 @@ _STRINGS = {
         "diagnosis_result_openai_title": "{personality} 뚱냥이가 배부른 이유예요.",
         "diagnosis_result_fallback_title": "뚱냥이가 배부른 이유예요.",
         "fallback_missing_api_key": "API 키 없음",
+        "missing_api_key_title": "API 키가 필요해요",
+        "missing_api_key_help": (
+            "🔑 AI 진단과 반려동물 테마를 켜려면\n"
+            "OpenAI API 키를 아래 파일에 넣어 주세요.\n"
+            "{path}\n\n"
+            "파일에 이렇게 한 줄만 적으면 됩니다.\n"
+            "OPENAI_API_KEY=sk-...\n\n"
+            "넣은 뒤 뚱냥이를 껐다 켜 주세요."
+        ),
         "fallback_api_error": "API 연결 실패",
         "fallback_worker_error": "진단 처리 실패",
         "fallback_unknown": "알 수 없는 오류",
@@ -152,6 +161,15 @@ _STRINGS = {
         "diagnosis_result_openai_title": "Here’s why your {personality} Memory Cat feels full.",
         "diagnosis_result_fallback_title": "Here’s why Memory Cat feels full.",
         "fallback_missing_api_key": "API key missing",
+        "missing_api_key_title": "An API key is needed",
+        "missing_api_key_help": (
+            "🔑 To turn on AI diagnosis and pet themes, put your OpenAI\n"
+            "API key in this file.\n"
+            "{path}\n\n"
+            "One line is all it needs.\n"
+            "OPENAI_API_KEY=sk-...\n\n"
+            "Then quit and reopen Memory Cat."
+        ),
         "fallback_api_error": "API connection failed",
         "fallback_worker_error": "Diagnosis processing failed",
         "fallback_unknown": "Unknown error",

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -1260,6 +1260,59 @@ class RevealTests(unittest.TestCase):
         self.assertTrue(acknowledged)
         controller.window.orderFrontRegardless.assert_called_once_with()
 
+    def test_pet_theme_asks_for_a_key_before_asking_for_a_photo(self):
+        controller = desktop_cat.CatController.alloc().init()
+        controller.language = "ko"
+        controller._pet_theme_running = False
+        controller._show_information_alert = Mock()
+        panel_class = Mock()
+
+        with (
+            patch.object(desktop_cat, "_load_api_key", return_value=None),
+            patch.object(desktop_cat, "NSOpenPanel", panel_class),
+        ):
+            controller.makePetTheme_(None)
+
+        # 사진 선택기를 아예 열지 않는다 -- 고르고 나서 실패하면 헛수고다.
+        panel_class.openPanel.assert_not_called()
+        title, body = controller._show_information_alert.call_args.args
+        self.assertEqual(title, "API 키가 필요해요")
+        self.assertIn("OPENAI_API_KEY=sk-...", body)
+        self.assertIn(".env", body)
+
+    def test_diagnosis_tells_you_where_to_put_the_key_when_it_is_missing(self):
+        content = desktop_cat.diagnosis_result_content(
+            {
+                "source": "fallback",
+                "fallback_reason": "missing_api_key",
+                "why_slow": ["디스크가 꽉 찼어요"],
+                "one_line_advice": "정리해보세요",
+                "estimated_reclaimable": "10 GB",
+            },
+            personality_label=DEFAULT_PERSONALITY,
+            language="ko",
+        )
+
+        self.assertIn("OPENAI_API_KEY=sk-...", content["body"])
+        self.assertIn(".env", content["body"])
+
+    def test_other_fallbacks_do_not_nag_about_the_key(self):
+        # 키가 있는데 API 가 실패한 경우다. 키 안내는 도움이 안 되고 방해만 된다.
+        for reason in ("api_error", "worker_error"):
+            with self.subTest(reason=reason):
+                content = desktop_cat.diagnosis_result_content(
+                    {
+                        "source": "fallback",
+                        "fallback_reason": reason,
+                        "why_slow": ["디스크가 꽉 찼어요"],
+                        "one_line_advice": "정리해보세요",
+                        "estimated_reclaimable": "10 GB",
+                    },
+                    personality_label=DEFAULT_PERSONALITY,
+                    language="ko",
+                )
+                self.assertNotIn("OPENAI_API_KEY=sk-...", content["body"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Both AI features degrade quietly without a key, and neither told the user how to fix that.

**The diagnosis** fell back to local rules and reported only `⚠️ 오프라인 진단 · 성격 미적용 · API 키 없음`. True, but it never said what to do about it — the user learns a key is missing and is left there.

**Making a pet theme** was worse. It opened the photo picker, let the user browse and choose a photo, started a worker thread, and only then failed with an error. All of that work happened before the one check that could have been done first.

## Now

The diagnosis result includes the path to write and the exact line to put in it:

```
⚠️ 오프라인 진단 · 성격 미적용 · API 키 없음

🔑 AI 진단과 반려동물 테마를 켜려면
OpenAI API 키를 아래 파일에 넣어 주세요.
/Users/you/Library/Application Support/Memory Cat/.env

파일에 이렇게 한 줄만 적으면 됩니다.
OPENAI_API_KEY=sk-...

넣은 뒤 뚱냥이를 껐다 켜 주세요.
```

The pet theme checks for a key **before** opening the picker, so nobody chooses a photo for nothing.

## What it deliberately does not do

The hint appears only when the key is genuinely missing. When a key exists and the API call failed — `api_error`, `worker_error` — telling someone to add a key is useless advice about a problem they do not have, so those fallbacks are untouched. A test pins that.

The path is read at runtime rather than hardcoded, so it names the user data directory in an installed app and the source folder when running from the repo. That matters now that the app is bundled: a hardcoded path would have been wrong in one of the two cases.

**136 passed, 2 skipped** (was 133); 3 new tests, including one asserting the picker is never opened without a key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)