### PR TITLE
Say how to run the build script from PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ pip install pyinstaller
 windows\build_exe.bat
 ```
 
+In PowerShell, prefix the script with `.\` — PowerShell does not run commands
+from the current directory otherwise, and reports the script as an unrecognized
+term:
+
+```powershell
+.\windows\build_exe.bat
+```
+
 > **The executable it produces is unsigned — expect security warnings.** This is
 > a personal project with no code-signing certificate, so the first launch of
 > `MemoryCat.exe` triggers a Windows SmartScreen "unknown publisher" prompt, and

--- a/windows/README.txt
+++ b/windows/README.txt
@@ -49,6 +49,13 @@
        pip install -r requirements.txt
        pip install pyinstaller
 2) build_exe.bat 더블클릭
+
+   터미널에서 돌린다면 쓰는 터미널에 따라 다릅니다.
+       명령 프롬프트(cmd)  :  build_exe.bat
+       PowerShell          :  .\build_exe.bat      <- 앞의 .\ 를 빼면 안 됩니다
+   PowerShell 은 보안상 현재 폴더의 명령을 자동으로 찾지 않아서,
+   .\ 없이 치면 "용어가 인식되지 않습니다" 오류가 납니다.
+
    (저장소 루트 등 다른 폴더에서  windows\build_exe.bat  으로 실행해도 됩니다.
     스크립트가 자기 폴더로 먼저 이동한 뒤 빌드합니다.)
 3) windows\dist\MemoryCat.exe 가 생김 -> 그거만 있으면 실행됨


### PR DESCRIPTION
Hit while building the Windows executable:

```
build_exe.bat : 'build_exe.bat' 용어가 cmdlet, 함수, 스크립트 파일 또는
실행할 수 있는 프로그램 이름으로 인식되지 않습니다.
```

PowerShell does not run commands from the current directory. The fix is `.\build_exe.bat`, and PowerShell does say so — in a suggestion below the stack-like error block, which is easy to scroll past. The error itself reads as though the file is missing.

Windows Terminal opens PowerShell by default now, so this is the first thing many people building from source will hit. Both READMEs now give the `.\` form next to the cmd form and explain why it is needed.

Docs only — **137 passed, 2 skipped**, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)