### PR TITLE
Give build_exe.bat CRLF endings so cmd can run it

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+* text=auto
+
+# Windows batch files MUST be CRLF. cmd.exe re-seeks through a batch file by
+# byte offset, and an LF-terminated .bat containing multi-byte characters
+# (Korean, here) throws that count off -- cmd then starts executing the middle
+# of a line as a command. The failure looks like a nonsense error such as
+# "'립트가'은(는) 내부 또는 외부 명령이 아닙니다" long before the real command runs.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# macOS and Unix scripts must stay LF, or the shebang line breaks.
+*.command text eol=lf
+*.sh      text eol=lf
+*.py      text eol=lf
+*.pyw     text eol=lf
+
+*.png  binary
+*.jpg  binary
+*.gif  binary
+*.icns binary
+*.heic binary

--- a/windows/build_exe.bat
+++ b/windows/build_exe.bat
@@ -1,4 +1,6 @@
 @echo off
+REM 한글 메시지가 cp949 콘솔에서 깨지지 않게 UTF-8 로 맞춘다.
+chcp 65001 >nul
 REM 메모리 뚱냥이 - Windows exe 빌드 스크립트
 REM 사전: pip install -r requirements.txt  그리고  pip install pyinstaller
 REM


### PR DESCRIPTION
Reported by someone building the Windows executable: the script never reaches pyinstaller and dies with a fragment of a Korean word as the command name.

```
'립트가'은(는) 내부 또는 외부 명령이 아닙니다
```

## Cause

`cmd.exe` walks a batch file by **byte offset**. When the file is LF-terminated and contains multi-byte characters, that count drifts and cmd begins executing the middle of a line as a command. The script collapses well before `pyinstaller` runs.

**This was introduced by #14.** The file had been uniformly LF and built fine:

```
before #14 :  CR 0  / LF 51     ← pure LF, built successfully
after  #14 :  CR 5  / LF 56     ← the five lines it added were CRLF
```

`git ls-files --eol` reported `i/mixed w/mixed`. `core.autocrlf` cannot repair that on checkout — git deliberately skips the conversion when a blob already contains CRLF, to avoid producing CRCRLF — so every Windows clone kept the broken mix.

Credit to the person who diagnosed this; the variable-isolation they did (CRLF+Korean fine, LF+ASCII fine, mixed+Korean broken) is what pinned it down.

## Fix

All 58 lines are CRLF. `.gitattributes` pins `.bat` and `.cmd` to CRLF so an editor or a future patch cannot reintroduce the mix, and keeps `.sh`, `.command`, `.py`, `.pyw` on LF — where a CRLF shebang would break them instead.

`git archive` honors the attribute too, so **the Download-ZIP path also gets CRLF**. Verified rather than assumed:

```
git archive HEAD → windows/build_exe.bat
  CR: 58 / LF: 58   → every LF is part of a CRLF
```

`git add --renormalize .` touched nothing else — only `.gitattributes` and the batch file are in this diff.

## Also

`chcp 65001` at the top of the script. Without it the script runs but its Korean messages arrive as mojibake on a cp949 console.

**137 passed, 2 skipped** — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)