### PR TITLE
Set the console codepage before the first Korean byte

### DIFF
--- a/tests/test_line_endings.py
+++ b/tests/test_line_endings.py
@@ -1,0 +1,75 @@
+"""줄바꿈이 잘못되면 그 파일을 쓰는 플랫폼에서만 깨진다.
+
+Windows 배치 파일은 CRLF 여야 하고(cmd 가 LF 파일을 잘못 읽는다), macOS 쪽
+스크립트는 LF 여야 한다(CRLF 면 shebang 이 깨진다). 둘 다 이 저장소의
+테스트로는 실행해 볼 수 없는 플랫폼이라, 바이트로 확인한다.
+
+.gitattributes 가 체크아웃 시 이걸 맞춰 주지만, 누가 손으로 저장하거나
+패치가 섞어 놓으면 워킹트리에서 어긋날 수 있다. 여기서 잡는다.
+"""
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _tracked(pattern):
+    """숨김 디렉터리(.git, .venv, 에이전트 워크트리)는 저장소 파일이 아니다."""
+    return sorted(
+        path
+        for path in ROOT.glob(pattern)
+        if not any(part.startswith(".") for part in path.relative_to(ROOT).parts)
+    )
+
+
+def _counts(path):
+    data = path.read_bytes()
+    return {
+        "crlf": data.count(b"\r\n"),
+        "lf": data.count(b"\n"),
+        "cr": data.count(b"\r"),
+        "bom": data[:3] == b"\xef\xbb\xbf",
+        "data": data,
+    }
+
+
+class LineEndingTests(unittest.TestCase):
+    def test_batch_files_are_entirely_crlf(self):
+        batch = _tracked("**/*.bat") + _tracked("**/*.cmd")
+        self.assertTrue(batch, "배치 파일을 못 찾았다면 경로 규칙이 낡은 것이다")
+        for path in batch:
+            with self.subTest(path=path.relative_to(ROOT)):
+                c = _counts(path)
+                # 홀로 있는 LF 가 하나라도 있으면 cmd 가 줄을 잘못 센다.
+                self.assertEqual(c["lf"], c["crlf"])
+                self.assertEqual(c["cr"], c["crlf"])
+                # 배치 파일 맨 앞의 BOM 은 cmd 가 첫 줄에서 걸려 넘어진다.
+                self.assertFalse(c["bom"])
+                # 마지막 줄에 개행이 없으면 cmd 가 그 줄을 놓칠 수 있다.
+                self.assertTrue(c["data"].endswith(b"\r\n"))
+
+    def test_unix_scripts_have_no_carriage_returns(self):
+        scripts = _tracked("**/*.command") + _tracked("**/*.sh")
+        self.assertTrue(scripts)
+        for path in scripts:
+            with self.subTest(path=path.relative_to(ROOT)):
+                # CRLF 면 shebang 이 "/bin/bash\r" 가 되어 실행 자체가 안 된다.
+                self.assertEqual(_counts(path)["cr"], 0)
+
+    def test_the_codepage_is_set_before_any_non_ascii_byte(self):
+        # 이 파일에는 한글이 들어 있다. 코드페이지를 맞추기 전에 한글 바이트가
+        # 나오면 콘솔에 깨져 보이고, 파서가 어긋날 여지도 남는다.
+        path = ROOT / "windows" / "build_exe.bat"
+        before = []
+        for line in path.read_bytes().decode("utf-8").splitlines():
+            if line.strip().lower().startswith("chcp "):
+                break
+            before.append(line)
+        else:
+            self.fail("chcp 줄을 찾지 못했다")
+        offenders = [line for line in before if not line.isascii()]
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/windows/build_exe.bat
+++ b/windows/build_exe.bat
@@ -1,6 +1,7 @@
 @echo off
-REM 한글 메시지가 cp949 콘솔에서 깨지지 않게 UTF-8 로 맞춘다.
 chcp 65001 >nul
+REM 위 줄이 먼저 와야 한다. 이 파일에는 한글이 들어 있는데, 코드페이지를
+REM 맞추기 전에 한글 바이트를 만나면 콘솔에 깨져 나오고 파서도 위태롭다.
 REM 메모리 뚱냥이 - Windows exe 빌드 스크립트
 REM 사전: pip install -r requirements.txt  그리고  pip install pyinstaller
 REM
@@ -27,6 +28,17 @@ if errorlevel 1 (
 if not exist "frames" (
     echo.
     echo [X] frames 폴더가 없습니다. 저장소를 통째로 받았는지 확인하세요.
+    popd
+    pause
+    exit /b 1
+)
+
+REM i18n.py 는 저장소 루트에 있다. windows 폴더만 복사해 온 경우 여기서
+REM 걸러 준다. 없으면 빌드는 되지만 실행할 때 죽는다.
+if not exist "..\i18n.py" (
+    echo.
+    echo [X] ..\i18n.py 를 찾을 수 없습니다.
+    echo     windows 폴더만 복사하지 말고 저장소를 통째로 받아 주세요.
     popd
     pause
     exit /b 1


### PR DESCRIPTION
Follow-up to #16, after an independent check of that fix. The fix was sound; **the explanation attached to it was not**, and one line was in the wrong order.

## #16's stated cause does not survive the bytes

The reported failure token `립트가` sits in **line 8**. #14 only touched **lines 33–37**. And the bytes preceding line 8 are byte-for-byte identical across both revisions:

```
"립트가" byte offset: 359  → line 8
lines changed by #14: 33-37
pre-#14 prefix == post-#14 prefix  → True
```

A batch file is read forward, so an edit at line 33 cannot cause a failure at line 8. **#14 was not the cause.** It did leave the file with mixed endings, and CRLF is still the right format — but the causal claim in #16 was wrong, and the "it built fine before #14" premise was an assumption, never a reproduction.

The variable matrix that was cited has a hole exactly there:

| | reported |
|---|---|
| CRLF + Korean | fine |
| LF + ASCII | fine |
| mixed + Korean | fails |
| **LF + Korean** | **never tested** ← this is what pre-#14 was |

The likeliest reading of the evidence is that LF + Korean was broken all along and nobody had built on a Korean-language Windows before. Correcting this matters: if it recurs, the wrong story sends the next investigation in the wrong direction.

## What changes here

**The codepage line moves to line 2.** #16 placed `chcp 65001` on line 3, *after* a Korean comment explaining it — laying a non-ASCII byte in front of the line that makes non-ASCII bytes safe. Backwards, and free to fix.

**A precheck for `../i18n.py`.** Since #14 the build pulls `i18n` from the repo root. Copy only the `windows` folder and the build still succeeds, producing an exe that dies at startup. It now fails immediately with a clear message instead of after minutes of PyInstaller.

**Tests, because there were none.** Line endings were guarded only by `.gitattributes`, which does nothing when a file is edited in place. `tests/test_line_endings.py` now asserts every `.bat` is wholly CRLF with no BOM and a trailing newline, every `.command`/`.sh` has no CR at all — a CRLF `install_mac.command` would break its shebang and take macOS down with it — and no Korean byte precedes `chcp`.

Confirmed the test actually catches the bug by converting three lines back to LF:

```
SUBFAILED(path=windows/build_exe.bat) test_batch_files_are_entirely_crlf
```

**143 passed, 2 skipped** (was 137).

## Still unverified

Nobody has run `cmd.exe` against any of this. The byte-offset explanation for cmd's behavior is widely repeated but was not confirmed here, and the actual trigger on the failing machine is still unknown. If the next build fails, the full console output up to the error is the only real evidence — worth capturing rather than re-guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)