### PR TITLE
Show the pet the user actually has in dialogs

### DIFF
--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -65,7 +65,8 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 # 자세한 규칙은 apppaths 모듈 참고.
 FRAMES_BASE = str(apppaths.bundled_frames_dir())
 USER_FRAMES_BASE = str(apppaths.user_frames_dir())
-ALERT_ICON_PATH = os.path.join(FRAMES_BASE, "cute", "cat_00.png")
+#: 테마를 못 읽을 때 쓰는 기본 아이콘. 번들 안이라 항상 있다.
+FALLBACK_ALERT_ICON_PATH = os.path.join(FRAMES_BASE, "cute", "cat_00.png")
 CONFIG = str(apppaths.config_file())
 REFRESH_SEC = 4.0
 DISK_FULL_NOTIFICATION_ID = "memory-cat-disk-full"
@@ -111,11 +112,27 @@ DEFAULT = {
 }
 
 
+def alert_icon_path():
+    """알럿에 띄울 아이콘 경로. 지금 고른 테마의 첫 프레임을 쓴다.
+
+    반려동물 사진으로 자기 테마를 만든 사람에게 기본 고양이를 보여 주면,
+    화면에 떠 있는 동물과 말을 거는 동물이 달라진다. 테마를 읽지 못하면
+    번들 안 기본 고양이로 돌아간다.
+    """
+    try:
+        candidate = frame_path(load_config()["theme"], 0)
+        if os.path.exists(candidate):
+            return candidate
+    except Exception:
+        pass
+    return FALLBACK_ALERT_ICON_PATH
+
+
 def new_cat_alert():
-    """Create an NSAlert with the bundled cat icon when it can be loaded."""
+    """Create an NSAlert showing the theme the user is actually running."""
     alert = NSAlert.alloc().init()
     try:
-        icon = NSImage.alloc().initWithContentsOfFile_(ALERT_ICON_PATH)
+        icon = NSImage.alloc().initWithContentsOfFile_(alert_icon_path())
         if icon is not None:
             alert.setIcon_(icon)
     except Exception:

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -13,7 +13,7 @@ from personality import CUSTOM_PERSONALITY, DEFAULT_PERSONALITY
 
 
 class DesktopCatTests(unittest.TestCase):
-    def test_new_cat_alert_uses_bundled_cat_frame_as_its_icon(self):
+    def test_new_cat_alert_uses_the_theme_the_user_is_running(self):
         alert = Mock()
         alert_class = Mock()
         alert_class.alloc.return_value.init.return_value = alert
@@ -29,7 +29,7 @@ class DesktopCatTests(unittest.TestCase):
 
         self.assertIs(created, alert)
         image_class.alloc.return_value.initWithContentsOfFile_.assert_called_once_with(
-            desktop_cat.ALERT_ICON_PATH
+            desktop_cat.alert_icon_path()
         )
         alert.setIcon_.assert_called_once_with(icon)
 
@@ -1312,6 +1312,37 @@ class RevealTests(unittest.TestCase):
                     language="ko",
                 )
                 self.assertNotIn("OPENAI_API_KEY=sk-...", content["body"])
+
+    def test_the_alert_icon_follows_a_custom_pet_theme(self):
+        # 반려동물 사진으로 테마를 만든 사람에게 기본 고양이가 말을 걸면 안 된다.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "myotter").mkdir()
+            for index in range(3):
+                (root / "myotter" / f"cat_{index:02d}.png").write_bytes(b"png")
+
+            with (
+                patch.object(desktop_cat, "USER_FRAMES_BASE", str(root)),
+                patch.object(desktop_cat, "load_config", return_value={"theme": "myotter"}),
+            ):
+                chosen = desktop_cat.alert_icon_path()
+
+        self.assertEqual(chosen, str(root / "myotter" / "cat_00.png"))
+
+    def test_the_alert_icon_falls_back_when_the_theme_is_gone(self):
+        # 테마 폴더를 지웠거나 config 가 깨졌어도 알럿은 떠야 한다.
+        with patch.object(
+            desktop_cat, "load_config", return_value={"theme": "deleted-theme"}
+        ):
+            self.assertEqual(
+                desktop_cat.alert_icon_path(), desktop_cat.FALLBACK_ALERT_ICON_PATH
+            )
+
+    def test_the_alert_icon_survives_a_broken_config(self):
+        with patch.object(desktop_cat, "load_config", side_effect=OSError("boom")):
+            self.assertEqual(
+                desktop_cat.alert_icon_path(), desktop_cat.FALLBACK_ALERT_ICON_PATH
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The alert icon was hardcoded:

```python
ALERT_ICON_PATH = os.path.join(FRAMES_BASE, "cute", "cat_00.png")
```

So someone running a theme built from a photo of their own pet saw **an otter on the desktop and a stock orange cat in every dialog** — including the "🐾 뚱냥이가 배불러요" prompt, which is exactly the moment the pet is supposed to be talking to them. The custom theme is the app's headline feature; the dialogs were ignoring it.

The icon now comes from whichever theme is selected. Verified against a real custom theme:

```
config theme     : mypet9
resolved icon    : ~/Library/Application Support/Memory Cat/frames/mypet9/cat_00.png
exists           : True
is not the default: True
```

**Falls back to the bundled cat** when the theme folder is gone or the config cannot be read — a dialog that cannot find an icon still has to appear, and the fallback lives inside the bundle so it is always there.

Uses the **first frame** rather than the current chonk stage. The same helper backs error dialogs and confirmations, where an identity portrait reads better than whatever roundness the disk happens to be at that moment.

**146 passed, 2 skipped** (was 143). Three new tests: a custom theme resolves to its own frame, a deleted theme falls back, and a config that raises falls back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)