### PR TITLE
Let the dialog pet be as round as the disk is full

### DIFF
--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -112,15 +112,37 @@ DEFAULT = {
 }
 
 
-def alert_icon_path():
-    """알럿에 띄울 아이콘 경로. 지금 고른 테마의 첫 프레임을 쓴다.
+def frame_index_for(theme, disk_percent):
+    """디스크 사용률을 그 테마의 프레임 번호로 옮긴다.
 
-    반려동물 사진으로 자기 테마를 만든 사람에게 기본 고양이를 보여 주면,
-    화면에 떠 있는 동물과 말을 거는 동물이 달라진다. 테마를 읽지 못하면
-    번들 안 기본 고양이로 돌아간다.
+    바탕화면 고양이와 알럿 아이콘이 같은 계산을 써야 한쪽만 다른 몸집으로
+    나오는 일이 없다.
+    """
+    n = frame_count(theme)
+    return int(round(disk_percent / 100 * (n - 1)))
+
+
+def alert_icon_path():
+    """알럿에 띄울 아이콘 경로. 지금 테마의, 지금 몸집으로 보여 준다.
+
+    반려동물 사진으로 자기 테마를 만든 사람에게 기본 고양이를 보여 주면
+    화면에 떠 있는 동물과 말을 거는 동물이 달라진다. 그리고 "배불러요" 라고
+    말하는 창에 홀쭉한 그림이 붙어 있으면 말과 그림이 따로 논다. 디스크가
+    찬 만큼 부푼 프레임을 쓴다.
+
+    테마나 사용률을 읽지 못하면 번들 안 기본 고양이로 돌아간다. 아이콘을
+    못 구했다고 알럿까지 안 뜨면 안 된다.
     """
     try:
-        candidate = frame_path(load_config()["theme"], 0)
+        theme = load_config()["theme"]
+    except Exception:
+        return FALLBACK_ALERT_ICON_PATH
+    try:
+        index = frame_index_for(theme, mc.disk_usage().percent)
+    except Exception:
+        index = 0  # 측정에 실패해도 그 테마의 얼굴은 보여 준다.
+    try:
+        candidate = frame_path(theme, index)
         if os.path.exists(candidate):
             return candidate
     except Exception:
@@ -711,8 +733,7 @@ class CatController(NSObject):
         self.score = dpct
         self._maybe_prompt_disk_full(dpct)
         theme = self.cfg["theme"]
-        n = frame_count(theme)
-        idx = int(round(dpct / 100 * (n - 1)))
+        idx = frame_index_for(theme, dpct)
         img = NSImage.alloc().initWithContentsOfFile_(frame_path(theme, idx))
         language = self.language
         self.view.updateImage_l1_l2_(

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -1313,21 +1313,62 @@ class RevealTests(unittest.TestCase):
                 )
                 self.assertNotIn("OPENAI_API_KEY=sk-...", content["body"])
 
-    def test_the_alert_icon_follows_a_custom_pet_theme(self):
-        # 반려동물 사진으로 테마를 만든 사람에게 기본 고양이가 말을 걸면 안 된다.
+    def test_the_alert_icon_follows_a_custom_pet_theme_and_its_current_size(self):
+        # 반려동물 사진으로 테마를 만든 사람에게 기본 고양이가 말을 걸면 안 되고,
+        # "배불러요" 라고 말하는 창에 홀쭉한 그림이 붙어 있어도 안 된다.
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             (root / "myotter").mkdir()
-            for index in range(3):
+            for index in range(11):
                 (root / "myotter" / f"cat_{index:02d}.png").write_bytes(b"png")
+
+            cases = {0.0: "cat_00.png", 50.0: "cat_05.png", 91.0: "cat_09.png",
+                     100.0: "cat_10.png"}
+            for percent, expected in cases.items():
+                with self.subTest(percent=percent):
+                    with (
+                        patch.object(desktop_cat, "USER_FRAMES_BASE", str(root)),
+                        patch.object(desktop_cat, "load_config",
+                                     return_value={"theme": "myotter"}),
+                        patch.object(desktop_cat.mc, "disk_usage",
+                                     return_value=SimpleNamespace(percent=percent)),
+                    ):
+                        chosen = desktop_cat.alert_icon_path()
+                    self.assertEqual(chosen, str(root / "myotter" / expected))
+
+    def test_the_alert_icon_still_appears_when_the_disk_cannot_be_measured(self):
+        # 측정이 실패해도 그 테마의 얼굴은 보여 준다. 아이콘 때문에 알럿이
+        # 안 뜨는 쪽이 나쁘다.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "myotter").mkdir()
+            (root / "myotter" / "cat_00.png").write_bytes(b"png")
 
             with (
                 patch.object(desktop_cat, "USER_FRAMES_BASE", str(root)),
                 patch.object(desktop_cat, "load_config", return_value={"theme": "myotter"}),
+                patch.object(desktop_cat.mc, "disk_usage", side_effect=OSError("boom")),
             ):
                 chosen = desktop_cat.alert_icon_path()
 
         self.assertEqual(chosen, str(root / "myotter" / "cat_00.png"))
+
+    def test_the_cat_and_the_alert_icon_use_the_same_frame_maths(self):
+        # 둘이 갈라지면 바탕화면과 대화상자의 몸집이 달라진다.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "myotter").mkdir()
+            for index in range(40):
+                (root / "myotter" / f"cat_{index:02d}.png").write_bytes(b"png")
+
+            with patch.object(desktop_cat, "USER_FRAMES_BASE", str(root)):
+                for percent in (0.0, 37.5, 91.0, 100.0):
+                    with self.subTest(percent=percent):
+                        index = desktop_cat.frame_index_for("myotter", percent)
+                        self.assertEqual(
+                            desktop_cat.frame_path("myotter", index),
+                            str(root / "myotter" / f"cat_{index:02d}.png"),
+                        )
 
     def test_the_alert_icon_falls_back_when_the_theme_is_gone(self):
         # 테마 폴더를 지웠거나 config 가 깨졌어도 알럿은 떠야 한다.


### PR DESCRIPTION
Follow-up to #18. That one made dialogs show the user's own theme, but kept the **first** frame — the slim one. So the disk-full prompt said **"뚱냥이가 배불러요"** next to a picture of a visibly not-full pet. The words and the picture disagreed, in the one dialog whose entire job is to convey a state.

The icon now uses the frame for the current disk usage — the same one the desktop pet is showing.

```
current disk : 91%
theme        : mypet9  (40 frames)
alert icon   : cat_35.png
```

Frame 35 of that theme is an otter flat on its belly, which is what "I'm full" should look like.

## Keeping the two in step

The index calculation moved into `frame_index_for(theme, disk_percent)` and both the desktop pet and the dialog call it. Previously the formula lived only inside `_refresh_once`; copying it would have let the two drift into showing different sizes for the same disk. A test pins that they agree.

## Falling back in two steps, not one

- Disk cannot be measured → the theme's **first frame** still appears. The pet is still the right animal.
- Theme folder missing or config unreadable → the bundled cat.

An icon problem must never be the reason a dialog does not appear.

**148 passed, 2 skipped** (was 146). The custom-theme test now checks four usage levels rather than one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)