### PR TITLE
Let the pet have a name, and stop assuming it is a cat

### DIFF
--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -47,6 +47,7 @@ from i18n import (
     LANGUAGE_OVERRIDES,
     chonk_stage,
     diagnosis_personality_descriptor,
+    pet_name,
     resolve_language,
     tr,
 )
@@ -105,6 +106,7 @@ SIZE_STRING_KEYS = {
 }
 DEFAULT = {
     "theme": "cute",
+    "pet_name": "",
     "size": "보통",
     "personality": DEFAULT_PERSONALITY,
     "custom_personality": "",
@@ -179,6 +181,7 @@ def load_config(path=None):
     cfg = dict(DEFAULT)
     if isinstance(loaded, dict):
         cfg["theme"] = loaded.get("theme", DEFAULT["theme"])
+        cfg["pet_name"] = str(loaded.get("pet_name", "") or "").strip()[:40]
         size = loaded.get("size", DEFAULT["size"])
         cfg["size"] = size if size in SIZES else DEFAULT["size"]
         selection, custom = config_personality(loaded)
@@ -309,11 +312,13 @@ def request_reveal(timeout=REVEAL_ACK_TIMEOUT_SEC):
 
 def show_already_running_alert(language=None):
     """부른 뚱냥이가 대답을 안 할 때만 뜨는 안내창."""
+    cfg = load_config()
     if language is None:
-        language = resolve_language(load_config()["language"])
+        language = resolve_language(cfg["language"])
+    name = pet_name(cfg.get("pet_name"), language)
     alert = new_cat_alert()
-    alert.setMessageText_(tr(language, "already_running_title"))
-    alert.setInformativeText_(tr(language, "already_running_body"))
+    alert.setMessageText_(tr(language, "already_running_title", pet=name))
+    alert.setInformativeText_(tr(language, "already_running_body", pet=name))
     alert.addButtonWithTitle_(tr(language, "confirm"))
     NSApp.activateIgnoringOtherApps_(True)
     alert.runModal()
@@ -329,9 +334,11 @@ def diagnosis_notification_text(result, language=LANGUAGE_KO):
     return "\n".join(lines) or tr(language, "diagnosis_empty")
 
 
-def diagnosis_result_content(result, personality_label, language=LANGUAGE_KO):
+def diagnosis_result_content(result, personality_label, language=LANGUAGE_KO,
+                             pet=None):
     """진단 JSON을 결과창에서 읽기 쉬운 제목·본문·동작으로 바꾼다."""
     help_text = None
+    pet = pet_name(pet, language)
     if result.get("source") == "openai":
         title = tr(
             language,
@@ -339,10 +346,11 @@ def diagnosis_result_content(result, personality_label, language=LANGUAGE_KO):
             personality=diagnosis_personality_descriptor(
                 personality_label, language
             ),
+            pet=pet,
         )
         source = None
     else:
-        title = tr(language, "diagnosis_result_fallback_title")
+        title = tr(language, "diagnosis_result_fallback_title", pet=pet)
         reason_key = {
             "missing_api_key": "fallback_missing_api_key",
             "api_error": "fallback_api_error",
@@ -669,6 +677,27 @@ class CatController(NSObject):
         except Exception:
             pass
 
+    @objc.python_method
+    def configuredPetName(self):
+        """설정에 저장된 원본 이름. 비어 있을 수 있다.
+
+        기본 호칭은 **문장을 만드는 쪽의 언어**로 정해져야 한다. 여기서 미리
+        확정해 버리면 진단이 도는 사이 언어를 바꿨을 때 한국어 문장에 영어
+        기본 이름이 섞인다.
+        """
+        return (getattr(self, "cfg", None) or {}).get("pet_name")
+
+    @objc.python_method
+    def petName(self):
+        """화면에 부를 이름. 안 지었으면 기본 호칭.
+
+        설정을 읽기 전에 알럿이 뜰 수도 있어서 없는 상태를 견딘다. 이름을
+        못 구했다고 창이 안 뜨면 안 된다.
+        """
+        cfg = getattr(self, "cfg", None) or {}
+        language = getattr(self, "language", LANGUAGE_KO)
+        return pet_name(cfg.get("pet_name"), language)
+
     def revealCat(self):
         """창을 화면 안쪽으로 되돌리고 맨 앞에 세운다.
 
@@ -837,11 +866,11 @@ class CatController(NSObject):
         self.cfg["personality"] = sender.representedObject()
         save_config(self.cfg)
         label = preset_label(self.cfg["personality"], self.language)
-        self._notify(tr(self.language, "personality_changed_title"), tr(self.language, "personality_changed_body", personality=label))
+        self._notify(tr(self.language, "personality_changed_title", pet=self.petName()), tr(self.language, "personality_changed_body", personality=label))
 
     def setCustomPersonality_(self, sender):
         alert = new_cat_alert()
-        alert.setMessageText_(tr(self.language, "custom_title"))
+        alert.setMessageText_(tr(self.language, "custom_title", pet=self.petName()))
         alert.setInformativeText_(tr(self.language, "custom_hint"))
         alert.addButtonWithTitle_(tr(self.language, "save"))
         alert.addButtonWithTitle_(tr(self.language, "cancel"))
@@ -861,6 +890,28 @@ class CatController(NSObject):
         save_config(self.cfg)
         self._notify(tr(self.language, "custom_saved_title"), custom)
 
+    def setPetName_(self, sender):
+        alert = new_cat_alert()
+        alert.setMessageText_(tr(self.language, "pet_name_title"))
+        alert.setInformativeText_(tr(self.language, "pet_name_hint"))
+        alert.addButtonWithTitle_(tr(self.language, "save"))
+        alert.addButtonWithTitle_(tr(self.language, "cancel"))
+        field = NSTextField.alloc().initWithFrame_(NSMakeRect(0, 0, 240, 28))
+        field.setStringValue_(self.cfg.get("pet_name", "") or "")
+        alert.setAccessoryView_(field)
+        NSApp.activateIgnoringOtherApps_(True)
+        if alert.runModal() != NSAlertFirstButtonReturn:
+            return
+
+        # 비우면 기본 호칭으로 돌아간다. 이름을 지우는 것도 선택이다.
+        self.cfg["pet_name"] = str(field.stringValue() or "").strip()[:40]
+        save_config(self.cfg)
+        self.refresh_(None)
+        self._notify(
+            tr(self.language, "pet_name_saved_title", pet=self.petName()),
+            tr(self.language, "pet_name_hint"),
+        )
+
     def setLanguage_(self, sender):
         self.cfg["language"] = sender.representedObject()
         self.language = resolve_language(self.cfg["language"])
@@ -877,7 +928,7 @@ class CatController(NSObject):
 
     def diagnose_(self, sender):
         if self._diagnosis_running:
-            self._notify(tr(self.language, "diagnosis_already_title"), tr(self.language, "diagnosis_already_body"))
+            self._notify(tr(self.language, "diagnosis_already_title"), tr(self.language, "diagnosis_already_body", pet=self.petName()))
             return
         personality, custom = config_personality(self.cfg)
         personality_display = (
@@ -891,7 +942,7 @@ class CatController(NSObject):
             "language": self.language,
         }
         self._diagnosis_running = True
-        self._notify(tr(self.language, "diagnosis_running_title"), tr(self.language, "diagnosis_running_body"))
+        self._notify(tr(self.language, "diagnosis_running_title"), tr(self.language, "diagnosis_running_body", pet=self.petName()))
         self._diagnosis_thread = threading.Thread(
             target=_diagnosis_worker,
             args=(personality, custom, self.language, self._finish_diagnosis),
@@ -960,7 +1011,7 @@ class CatController(NSObject):
     @objc.python_method
     def _show_disk_full_prompt(self):
         notification = NSUserNotification.alloc().init()
-        notification.setTitle_(tr(self.language, "disk_full_prompt_title"))
+        notification.setTitle_(tr(self.language, "disk_full_prompt_title", pet=self.petName()))
         notification.setInformativeText_(
             tr(self.language, "disk_full_prompt_body")
         )
@@ -983,7 +1034,7 @@ class CatController(NSObject):
     def _show_disk_full_alert(self):
         """알림이 뜨지 않는 환경을 위한 대체 경로. 진단으로 바로 이어준다."""
         alert = new_cat_alert()
-        alert.setMessageText_(tr(self.language, "disk_full_prompt_title"))
+        alert.setMessageText_(tr(self.language, "disk_full_prompt_title", pet=self.petName()))
         alert.setInformativeText_(tr(self.language, "disk_full_prompt_body"))
         alert.addButtonWithTitle_(tr(self.language, "disk_full_prompt_action"))
         alert.addButtonWithTitle_(tr(self.language, "close"))
@@ -1032,6 +1083,7 @@ class CatController(NSObject):
             result,
             personality_label=context["personality_label"],
             language=language,
+            pet=self.configuredPetName(),
         )["title"]
         if not self._notify(title, body):
             self._show_information_alert(title, body)
@@ -1057,6 +1109,7 @@ class CatController(NSObject):
             result,
             personality_label=context["personality_label"],
             language=language,
+            pet=self.configuredPetName(),
         )
         alert = new_cat_alert()
         alert.setMessageText_(content["title"])
@@ -1292,6 +1345,12 @@ class CatController(NSObject):
         )
         language_item.setSubmenu_(language_menu)
         menu.addItem_(language_item)
+
+        name_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            tr(self.language, "menu_pet_name"), b"setPetName:", ""
+        )
+        name_item.setTarget_(self)
+        menu.addItem_(name_item)
 
         menu.addItem_(NSMenuItem.separatorItem())
         r = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(tr(self.language, "menu_refresh"), b"refresh:", "")

--- a/i18n.py
+++ b/i18n.py
@@ -33,9 +33,9 @@ _STRINGS = {
         "diagnosis_empty": "진단 결과를 만들지 못했습니다. 잠시 후 다시 시도해 주세요.",
         "diagnosis_error": "진단 데이터를 읽는 중 문제가 생겼습니다.",
         "retry_later": "잠시 후 다시 시도해 주세요.",
-        "personality_changed_title": "뚱냥이 성격 변경",
+        "personality_changed_title": "{pet} 성격 변경",
         "personality_changed_body": "이제 {personality} 말투로 진단할게요.",
-        "custom_title": "뚱냥이 성격을 직접 알려 주세요",
+        "custom_title": "{pet} 성격을 직접 알려 주세요",
         "custom_hint": "예: 다정하지만 핵심만 말하고, 말끝에 냥을 붙여줘",
         "save": "저장",
         "cancel": "취소",
@@ -44,13 +44,17 @@ _STRINGS = {
         "custom_saved_title": "커스텀 성격 저장",
         "personality_custom_label": "직접 입력",
         "diagnosis_already_title": "🧠 이미 진단 중이에요",
-        "diagnosis_already_body": "뚱냥이가 숫자를 살펴보고 있습니다.",
+        "diagnosis_already_body": "{pet}가 숫자를 살펴보고 있습니다.",
         "diagnosis_running_title": "🐾 살펴보는 중…",
-        "diagnosis_running_body": "뚱냥이가 얼마나 배부른지 살펴보고 있어요.",
+        "diagnosis_running_body": "{pet}가 얼마나 배부른지 살펴보고 있어요.",
         "diagnosis_source_fallback": "⚠️ 오프라인 진단 · 성격 미적용 · {reason}",
-        "diagnosis_result_openai_title": "{personality} 뚱냥이가 배부른 이유예요.",
-        "diagnosis_result_fallback_title": "뚱냥이가 배부른 이유예요.",
+        "diagnosis_result_openai_title": "{personality} {pet}가 배부른 이유예요.",
+        "diagnosis_result_fallback_title": "{pet}가 배부른 이유예요.",
         "fallback_missing_api_key": "API 키 없음",
+        "menu_pet_name": "이름 지어주기…",
+        "pet_name_title": "뭐라고 부를까요?",
+        "pet_name_hint": "비워 두면 뚱냥이라고 부릅니다.",
+        "pet_name_saved_title": "이제 {pet}라고 부를게요",
         "missing_api_key_title": "API 키가 필요해요",
         "missing_api_key_help": (
             "🔑 AI 진단과 반려동물 테마를 켜려면\n"
@@ -101,12 +105,12 @@ _STRINGS = {
         "pet_theme_complete_title": "반려동물 테마 완성",
         "pet_theme_complete_body": "{count}단계를 감지해 {theme} 테마를 바로 적용했어요.",
         "pet_theme_error_title": "테마를 만들지 못했어요",
-        "disk_full_prompt_title": "🐾 뚱냥이가 배불러요",
+        "disk_full_prompt_title": "🐾 {pet}가 배불러요",
         "disk_full_prompt_body": "배불러… 진단해볼까?",
         "disk_full_prompt_action": "진단하기",
-        "already_running_title": "뚱냥이는 이미 한 마리 있어요",
+        "already_running_title": "{pet}는 이미 한 마리 있어요",
         "already_running_body": (
-            "고양이를 불러 봤는데 대답이 없네요. 화면 어딘가에 숨어 있거나 "
+            "{pet}를 불러 봤는데 대답이 없네요. 화면 어딘가에 숨어 있거나 "
             "멈춰 있을 수 있어요. 우클릭 메뉴에서 종료한 뒤 다시 열어 주세요."
         ),
         "menu_size": "크기",
@@ -143,9 +147,9 @@ _STRINGS = {
         "diagnosis_empty": "I couldn't produce a diagnosis. Please try again shortly.",
         "diagnosis_error": "Something went wrong while reading the diagnostic data.",
         "retry_later": "Please try again shortly.",
-        "personality_changed_title": "Cat personality changed",
+        "personality_changed_title": "{pet} personality changed",
         "personality_changed_body": "Future diagnoses will use the {personality} voice.",
-        "custom_title": "Describe your cat's personality",
+        "custom_title": "Describe {pet}'s personality",
         "custom_hint": "Example: Be kind, lead with the key point, and end sentences with meow.",
         "save": "Save",
         "cancel": "Cancel",
@@ -154,13 +158,17 @@ _STRINGS = {
         "custom_saved_title": "Custom personality saved",
         "personality_custom_label": "Custom",
         "diagnosis_already_title": "🧠 Diagnosis already running",
-        "diagnosis_already_body": "The cat is still inspecting the numbers.",
+        "diagnosis_already_body": "{pet} is still inspecting the numbers.",
         "diagnosis_running_title": "🐾 Checking…",
-        "diagnosis_running_body": "Memory Cat is checking how full things feel.",
+        "diagnosis_running_body": "{pet} is checking how full things feel.",
         "diagnosis_source_fallback": "⚠️ Offline diagnosis · Personality not applied · {reason}",
-        "diagnosis_result_openai_title": "Here’s why your {personality} Memory Cat feels full.",
-        "diagnosis_result_fallback_title": "Here’s why Memory Cat feels full.",
+        "diagnosis_result_openai_title": "Here’s why your {personality} {pet} feels full.",
+        "diagnosis_result_fallback_title": "Here’s why {pet} feels full.",
         "fallback_missing_api_key": "API key missing",
+        "menu_pet_name": "Give it a name…",
+        "pet_name_title": "What should I call it?",
+        "pet_name_hint": "Leave it empty to keep calling it Memory Cat.",
+        "pet_name_saved_title": "I'll call it {pet} from now on",
         "missing_api_key_title": "An API key is needed",
         "missing_api_key_help": (
             "🔑 To turn on AI diagnosis and pet themes, put your OpenAI\n"
@@ -211,14 +219,14 @@ _STRINGS = {
         "pet_theme_complete_title": "Pet theme ready",
         "pet_theme_complete_body": "Detected {count} stages and applied the {theme} theme.",
         "pet_theme_error_title": "Couldn't make the theme",
-        "disk_full_prompt_title": "🐾 Memory Cat is full",
+        "disk_full_prompt_title": "🐾 {pet} is full",
         "disk_full_prompt_body": "I'm so full… want a checkup?",
         "disk_full_prompt_action": "Run checkup",
-        "already_running_title": "Memory Cat is already running",
+        "already_running_title": "{pet} is already running",
         "already_running_body": (
-            "The running cat did not answer. It may be hidden somewhere on "
+            "{pet} did not answer. It may be hidden somewhere on "
             "screen, or stuck. Quit it from the right-click menu and open "
-            "Memory Cat again."
+            "it again."
         ),
         "menu_size": "Size",
         "menu_personality": "Personality",
@@ -301,16 +309,30 @@ def diagnosis_personality_descriptor(label: str, language: str) -> str:
     return _DIAGNOSIS_PERSONALITY_DESCRIPTORS[lang].get(label, default)
 
 
+#: 이름을 안 지어 줬을 때 쓰는 기본 호칭.
+DEFAULT_PET_NAME = {LANGUAGE_KO: "뚱냥이", LANGUAGE_EN: "Memory Cat"}
+
+
+def pet_name(configured: Optional[str], language: str) -> str:
+    """화면에 부를 이름. 안 지었으면 기본 호칭으로 돌아간다.
+
+    사진으로 테마를 만들면 고양이가 아닐 수 있어서, "뚱냥이" 를 그대로 쓰면
+    수달한테 냥이라고 부르게 된다.
+    """
+    name = str(configured or "").strip()
+    return name or DEFAULT_PET_NAME[canonical_language(language)]
+
+
 def chonk_stage(percent: float, language: str) -> str:
     """한국어는 기존 4단계를 유지하고 영어만 6단계 chonk chart를 쓴다."""
     if canonical_language(language) == LANGUAGE_KO:
         if percent < 60:
-            return "여유 😺"
+            return "여유"
         if percent < 80:
-            return "포동 🐈"
+            return "포동"
         if percent < 92:
-            return "배불러 🍙"
-        return "빵빵! 🐷"
+            return "배불러"
+        return "빵빵!"
 
     if percent < 60:
         return CHONK_STAGES_EN[0]

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -1182,11 +1182,29 @@ class SecondLaunchTests(unittest.TestCase):
             desktop_cat.show_already_running_alert("en")
 
         alert.setMessageText_.assert_called_once_with(
-            i18n.tr("en", "already_running_title")
+            i18n.tr("en", "already_running_title", pet="Memory Cat")
         )
         alert.setInformativeText_.assert_called_once_with(
-            i18n.tr("en", "already_running_body")
+            i18n.tr("en", "already_running_body", pet="Memory Cat")
         )
+
+    def test_already_running_alert_uses_the_name_the_user_gave(self):
+        alert = Mock()
+
+        with (
+            patch.object(desktop_cat, "new_cat_alert", return_value=alert),
+            patch.object(desktop_cat, "NSApp", Mock()),
+            patch.object(
+                desktop_cat,
+                "load_config",
+                return_value={"language": "ko", "pet_name": "몽이"},
+            ),
+        ):
+            desktop_cat.show_already_running_alert()
+
+        title = alert.setMessageText_.call_args.args[0]
+        self.assertIn("몽이", title)
+        self.assertNotIn("뚱냥이", title)
 
 
 class RevealTests(unittest.TestCase):
@@ -1384,6 +1402,88 @@ class RevealTests(unittest.TestCase):
             self.assertEqual(
                 desktop_cat.alert_icon_path(), desktop_cat.FALLBACK_ALERT_ICON_PATH
             )
+
+    def test_the_diagnosis_calls_the_pet_by_the_name_the_user_gave(self):
+        result = {
+            "source": "openai",
+            "why_slow": ["디스크가 꽉 찼어요"],
+            "one_line_advice": "정리해보세요",
+            "estimated_reclaimable": "12 GB",
+        }
+        named = desktop_cat.diagnosis_result_content(
+            result, personality_label="따뜻함", language="ko", pet="몽이"
+        )
+        self.assertIn("몽이", named["title"])
+        self.assertNotIn("뚱냥이", named["title"])
+
+        unnamed = desktop_cat.diagnosis_result_content(
+            result, personality_label="따뜻함", language="ko", pet=""
+        )
+        self.assertIn("뚱냥이", unnamed["title"])
+
+    def test_the_default_name_follows_the_language_of_the_message(self):
+        # 진단이 도는 사이 언어를 바꾸면, 문장은 한국어인데 이름만 영어가 될
+        # 수 있었다. 기본 호칭은 문장을 만드는 쪽 언어를 따라야 한다.
+        result = {
+            "source": "fallback",
+            "fallback_reason": "api_error",
+            "why_slow": ["x"],
+            "one_line_advice": "y",
+            "estimated_reclaimable": "1 GB",
+        }
+        for language, expected in (("ko", "뚱냥이"), ("en", "Memory Cat")):
+            with self.subTest(language=language):
+                content = desktop_cat.diagnosis_result_content(
+                    result, personality_label="따뜻함", language=language, pet=None
+                )
+                self.assertIn(expected, content["title"])
+
+    def test_naming_the_pet_stores_a_trimmed_name(self):
+        controller = desktop_cat.CatController.alloc().init()
+        controller.cfg = dict(desktop_cat.DEFAULT)
+        controller.language = "ko"
+        controller.refresh_ = Mock()
+        controller._notify = Mock(return_value=True)
+        alert = Mock()
+        alert.runModal.return_value = desktop_cat.NSAlertFirstButtonReturn
+        field = Mock()
+        field.stringValue.return_value = "  몽이  "
+
+        with (
+            patch.object(desktop_cat, "new_cat_alert", return_value=alert),
+            patch.object(desktop_cat, "NSApp", Mock()),
+            patch.object(desktop_cat, "NSTextField", Mock(
+                **{"alloc.return_value.initWithFrame_.return_value": field})),
+            patch.object(desktop_cat, "save_config", return_value=True) as save,
+        ):
+            controller.setPetName_(None)
+
+        self.assertEqual(controller.cfg["pet_name"], "몽이")
+        save.assert_called_once_with(controller.cfg)
+
+    def test_clearing_the_name_goes_back_to_the_default(self):
+        # 이름을 지우는 것도 선택이다. 빈 칸이면 기본 호칭으로 돌아가야 한다.
+        controller = desktop_cat.CatController.alloc().init()
+        controller.cfg = dict(desktop_cat.DEFAULT, pet_name="몽이")
+        controller.language = "ko"
+        controller.refresh_ = Mock()
+        controller._notify = Mock(return_value=True)
+        alert = Mock()
+        alert.runModal.return_value = desktop_cat.NSAlertFirstButtonReturn
+        field = Mock()
+        field.stringValue.return_value = "   "
+
+        with (
+            patch.object(desktop_cat, "new_cat_alert", return_value=alert),
+            patch.object(desktop_cat, "NSApp", Mock()),
+            patch.object(desktop_cat, "NSTextField", Mock(
+                **{"alloc.return_value.initWithFrame_.return_value": field})),
+            patch.object(desktop_cat, "save_config", return_value=True),
+        ):
+            controller.setPetName_(None)
+
+        self.assertEqual(controller.cfg["pet_name"], "")
+        self.assertEqual(controller.petName(), "뚱냥이")
 
 
 if __name__ == "__main__":

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -18,11 +18,23 @@ class I18nTests(unittest.TestCase):
         stages = [i18n.chonk_stage(value, "en") for value in (50, 65, 75, 85, 92, 99)]
         self.assertEqual(tuple(stages), i18n.CHONK_STAGES_EN)
 
-    def test_korean_growth_stages_are_unchanged(self):
-        self.assertEqual(
-            [i18n.chonk_stage(value, "ko") for value in (50, 70, 85, 95)],
-            ["여유 😺", "포동 🐈", "배불러 🍙", "빵빵! 🐷"],
-        )
+    def test_korean_growth_stages_carry_no_animal_emoji(self):
+        # 사진으로 만든 테마는 고양이가 아닐 수 있다. 고양이 이모지가 붙어
+        # 있으면 수달한테 냥이라고 부르는 꼴이 된다.
+        stages = [i18n.chonk_stage(value, "ko") for value in (50, 70, 85, 95)]
+        self.assertEqual(stages, ["여유", "포동", "배불러", "빵빵!"])
+        for stage in stages:
+            with self.subTest(stage=stage):
+                self.assertTrue(all(ord(ch) < 0x1F300 for ch in stage))
+
+    def test_the_pet_name_falls_back_to_the_default_when_unset(self):
+        self.assertEqual(i18n.pet_name("", "ko"), "뚱냥이")
+        self.assertEqual(i18n.pet_name(None, "en"), "Memory Cat")
+        self.assertEqual(i18n.pet_name("   ", "ko"), "뚱냥이")
+
+    def test_the_pet_name_is_used_when_the_user_named_one(self):
+        self.assertEqual(i18n.pet_name("몽이", "ko"), "몽이")
+        self.assertEqual(i18n.pet_name("  Mongi  ", "en"), "Mongi")
 
     def test_translation_can_format_a_language_placeholder(self):
         self.assertEqual(


### PR DESCRIPTION
Making a theme from a photo is the headline feature, so the pet on screen is often not a cat. Every dialog still called it **뚱냥이**, and the growth stages were tagged 😺 and 🐈. An otter was being addressed as a kitten:

> 따뜻한 **뚱냥이**가 배부른 이유예요.

## The name is a setting now

Ten strings in each language take a `{pet}` placeholder, and **이름 지어주기… / Give it a name…** in the right-click menu sets it.

```
named   : 따뜻한 몽이가 배부른 이유예요.
unnamed : 따뜻한 뚱냥이가 배부른 이유예요.
```

Leaving the field empty **clears** the name and goes back to 뚱냥이 / Memory Cat — clearing is a choice too, and anyone who never opens that menu sees exactly what they see today. Nothing to migrate.

This also dissolves the original awkwardness: "따뜻한 뚱냥이" read as padding because the personality adjective had nothing to do with fullness, but "따뜻한 몽이" is just a name with a manner.

## Emoji removed from the Korean stages

`여유 😺` → `여유`. There is no emoji that works for every animal someone might photograph, so none is better than a cat one. A test asserts the stages carry no emoji at all rather than pinning the specific strings, so this cannot quietly come back.

## Two implementation notes

**The default name resolves where the sentence is built**, not where it is read from config. Resolving it early was wrong and a test caught it — the language of the diagnosis is captured when it starts, so switching language mid-diagnosis produced a Korean sentence with an English default:

```
Expected: 냉소적인 뚱냥이가 배부른 이유예요.
Actual  : 냉소적인 Memory Cat가 배부른 이유예요.
```

**`petName()` tolerates a controller with no config yet.** An alert that cannot work out a name still has to appear; that was also found by a failing test rather than guessed at.

**155 passed, 2 skipped** (was 148). Seven new tests, including clearing the name and the language-mismatch case above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)