### PR TITLE
Stop a test from reading the real config

### DIFF
--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -1178,6 +1178,11 @@ class SecondLaunchTests(unittest.TestCase):
         with (
             patch.object(desktop_cat, "new_cat_alert", return_value=alert),
             patch.object(desktop_cat, "NSApp", Mock()),
+            # 이 함수는 설정 파일을 직접 읽는다. 패치하지 않으면 테스트를
+            # 돌리는 사람이 펫에게 지어 준 이름이 결과에 섞여 들어온다.
+            patch.object(
+                desktop_cat, "load_config", return_value={"language": "en"}
+            ),
         ):
             desktop_cat.show_already_running_alert("en")
 


### PR DESCRIPTION
The suite fails on any machine where the pet has been given a name:

```
Expected: setMessageText_('Memory Cat is already running')
  Actual: setMessageText_('수다리 is already running')
```

`show_already_running_alert` reads `config.json` itself to work out the language and the pet's name. The test covering it patched neither, so it only passed while nobody had used the naming feature — the feature the same release introduced. The first person to name their pet gets a red suite that tells them nothing about their code.

Patching `load_config` makes the test depend on its inputs rather than on whoever runs it. Verified both ways: it now passes with a name set in the real config, and with the config pointed at `/dev/null`.

Found because the suite went red on a machine right after the pet was named — worth noting the failure was real, not flaky.

**155 passed, 2 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)