### PR TITLE
macOS 릴리스를 자립 번들로 굽는다 (+ 인텔 CI 수정)

### DIFF
--- a/.github/workflows/build-intel-mac.yml
+++ b/.github/workflows/build-intel-mac.yml
@@ -1,0 +1,179 @@
+name: Build Intel macOS app
+
+# 애플 실리콘 zip 은 손으로 만들어 올리지만, 인텔용은 인텔 맥이 있어야 한다.
+# psutil / jiter / Pillow 에는 universal2 휠이 없어서 한 대에서 두 아키텍처를
+# 다 만들 수 없다. macos-13 러너가 x86_64 라 여기서 굽는다.
+#
+# 굽는 방법은 `macos/memorycat.spec`(PyInstaller) 하나뿐이다.
+# `macos/build_app.py` 로 구우면 안 된다 — 그건 로컬 설치용 조립기라서 굽는
+# 기계의 인터프리터를 절대경로로 물고 표준 라이브러리도 거기서 빌려 쓴다.
+# 러너에서 돌리면 그 자리에 hostedtoolcache 경로가 박히는데, 그건 어느
+# 사용자 맥에도 없다. 받는 사람은 LSUIElement 때문에 에러도 창도 없이
+# "아무 일도 안 일어남" 만 겪는다. v0.1.0 의 macOS zip 이 정확히 그랬다.
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    # macos-14 부터는 arm64 다. 인텔 산출물을 만들려면 13 이어야 한다.
+    runs-on: macos-13
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 러너가 정말 인텔인지 확인
+        run: |
+          set -euo pipefail
+          arch="$(uname -m)"
+          echo "runner arch: $arch"
+          if [ "$arch" != "x86_64" ]; then
+            echo "::error::인텔 러너가 아닙니다 ($arch). runs-on 을 확인하세요."
+            exit 1
+          fi
+
+      - name: 의존성 설치
+        run: |
+          set -euo pipefail
+          python -m venv .venv
+          # 이 순서를 바꾸면 안 된다. 낡은 pip 은 pyobjc-core 휠을 못 찾고
+          # 소스 빌드로 넘어가 컴파일러가 없다며 실패한다.
+          ./.venv/bin/python -m pip install --upgrade pip
+          # numpy<2 인 이유와 릴리스 빌드 규칙은 requirements-release.txt 참고.
+          ./.venv/bin/python -m pip install \
+            -r requirements.txt "numpy<2" \
+            -r requirements-release.txt \
+            -r requirements-dev.txt
+
+      - name: 번들 굽기
+        run: |
+          set -euo pipefail
+          ./.venv/bin/python -m PyInstaller --noconfirm --clean \
+            macos/memorycat.spec
+
+      - name: 자립성 검증 (이게 핵심이다)
+        run: |
+          set -euo pipefail
+          app="dist/Memory Cat.app"
+
+          echo "--- 굽는 기계에 묶인 절대경로가 없는지 ---"
+          # 시스템 라이브러리와 @rpath/@loader_path 외의 절대경로가 하나라도
+          # 있으면 그 경로가 없는 맥에서 dyld 가 프로세스를 죽인다.
+          # v0.1.0 을 못 쓰게 만든 결함이 정확히 이것이고, 예전 워크플로는
+          # 이 검사가 없어서 통과시켰다.
+          bad=0
+          while IFS= read -r file; do
+            [ -n "$(lipo -archs "$file" 2>/dev/null || true)" ] || continue
+            while IFS= read -r dep; do
+              case "$dep" in
+                /usr/lib/*|/System/*|@rpath/*|@loader_path/*|@executable_path/*) ;;
+                *) echo "::error::외부 절대경로: ${file#"$app/"} -> $dep"; bad=1 ;;
+              esac
+            done < <(otool -L "$file" 2>/dev/null | tail -n +2 | awk '{print $1}')
+          done < <(find "$app" -type f ! -type l)
+          [ "$bad" -eq 0 ] || exit 1
+          echo "OK: 외부 절대경로 0건"
+
+          echo "--- 굽는 기계의 경로 문자열이 남지 않았는지 ---"
+          if grep -rlE "hostedtoolcache|/Users/runner/work" "$app" 2>/dev/null \
+              | grep -v "site-packages/\(jiter\|pydantic_core\)" | head -5; then
+            echo "::warning::러너 경로 문자열이 남아 있습니다(위 목록 확인)"
+          fi
+
+          echo "--- 아키텍처 ---"
+          # 번들 안 모든 Mach-O 가 x86_64 를 지원해야 인텔 맥에서 돈다.
+          bad=0
+          while IFS= read -r file; do
+            archs="$(lipo -archs "$file" 2>/dev/null || true)"
+            [ -z "$archs" ] && continue
+            case "$archs" in
+              *x86_64*) ;;
+              *) echo "::error::x86_64 미지원: ${file#"$app/"} [$archs]"; bad=1 ;;
+            esac
+          done < <(find "$app" -type f ! -type l)
+          [ "$bad" -eq 0 ] || exit 1
+          echo "OK: 전부 x86_64 지원"
+
+          echo "--- 번들 정체성 ---"
+          plutil -lint "$app/Contents/Info.plist"
+          got="$(plutil -extract CFBundleIdentifier raw \
+            "$app/Contents/Info.plist")"
+          if [ "$got" != "com.memorycat.desktop" ]; then
+            echo "::error::기대한 번들 ID 가 아닙니다: $got"; exit 1
+          fi
+          # 실행 파일 이름이 바뀌면 install_mac.command 로 깐 사람의
+          # LaunchAgent 가 깨진다. 그쪽은 절대경로로 MemoryCat 을 가리킨다.
+          exe="$(plutil -extract CFBundleExecutable raw \
+            "$app/Contents/Info.plist")"
+          if [ "$exe" != "MemoryCat" ]; then
+            echo "::error::실행 파일 이름이 바뀌었습니다: $exe"; exit 1
+          fi
+          echo "OK: $got / $exe"
+
+          echo "--- 개인 정보가 섞이지 않았는지 ---"
+          # 개발용 frames/ 에는 실제 반려동물 사진으로 만든 테마가 쌓인다.
+          # 한 번 나가면 되돌릴 수 없다.
+          leak="$(find "$app" \( -name '.env' -o -name 'config.json' \
+            -o -iname '*mypet*' -o -iname '*gandi*' -o -iname '*dog-hero*' \
+            -o -iname '*livetest*' \) | head -5)"
+          if [ -n "$leak" ]; then
+            echo "::error::번들에 개인 자료가 있습니다:"; echo "$leak"; exit 1
+          fi
+          echo "OK: 개인 자료 0건"
+
+      - name: OS 하한이 선언값과 맞는지
+        # 번들 안 모든 Mach-O 의 minos 를 읽어 가장 높은 값과 Info.plist 의
+        # LSMinimumSystemVersion 을 대조한다. 낮게 적으면 그 사이 macOS 에서
+        # 조용히 죽는다. 러너 인터프리터가 하한을 올리면 여기서 걸린다.
+        run: |
+          set -euo pipefail
+          MEMORY_CAT_BUNDLE="dist/Memory Cat.app" \
+            ./.venv/bin/python -m pytest -q \
+            tests/test_macos_bundle.py::BuiltBundleFloorTests
+
+      - name: 전체 테스트
+        run: |
+          set -euo pipefail
+          MEMORY_CAT_HOME="$RUNNER_TEMP/memory-cat-home" \
+            ./.venv/bin/python -m pytest -q
+
+      - name: zip 만들기
+        run: |
+          set -euo pipefail
+          # ditto 로만 포장한다. zip -r 은 심볼릭 링크를 따라가서 실체를
+          # 복사하고, 그 과정에서 ad-hoc 서명이 깨진다. 그러면 macOS 가
+          # "손상되었기 때문에 열 수 없습니다" 를 띄운다.
+          ditto -c -k --sequesterRsrc --keepParent \
+            "dist/Memory Cat.app" "Memory-Cat-macOS-Intel.zip"
+          shasum -a 256 Memory-Cat-macOS-Intel.zip | tee checksum.txt
+
+      - name: 포장한 zip 을 다시 풀어 서명 확인
+        run: |
+          set -euo pipefail
+          ditto -x -k Memory-Cat-macOS-Intel.zip roundtrip
+          codesign --verify --deep --strict "roundtrip/Memory Cat.app"
+          echo "OK: 왕복 후에도 서명이 온전함"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Memory-Cat-macOS-Intel
+          path: |
+            Memory-Cat-macOS-Intel.zip
+            checksum.txt
+
+      # 릴리스에서 실행됐을 때만 붙인다. 수동 실행은 아티팩트로만 받아 보고
+      # 확인한 뒤 사람이 올린다.
+      # 위 검증 단계가 하나라도 실패하면 잡이 멈춰서 여기까지 오지 않는다.
+      - name: 릴리스에 첨부
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" Memory-Cat-macOS-Intel.zip --clobber

--- a/.github/workflows/build-intel-mac.yml
+++ b/.github/workflows/build-intel-mac.yml
@@ -72,12 +72,26 @@ jobs:
           bad=0
           while IFS= read -r file; do
             [ -n "$(lipo -archs "$file" 2>/dev/null || true)" ] || continue
+
+            # 로드 의존(LC_LOAD_DYLIB 등). otool -L 이 보여 주는 것들.
             while IFS= read -r dep; do
               case "$dep" in
                 /usr/lib/*|/System/*|@rpath/*|@loader_path/*|@executable_path/*) ;;
                 *) echo "::error::외부 절대경로: ${file#"$app/"} -> $dep"; bad=1 ;;
               esac
             done < <(otool -L "$file" 2>/dev/null | tail -n +2 | awk '{print $1}')
+
+            # LC_RPATH 도 본다. otool -L 은 rpath 항목을 안 보여 주는데,
+            # @rpath 가 어디로 풀리는지는 이쪽이 정한다. 번들 밖을 가리키는
+            # rpath 가 앞에 오면 그 경로가 있는 기계에서 다른 라이브러리를
+            # 집어 올 수 있다.
+            while IFS= read -r rp; do
+              case "$rp" in
+                @loader_path*|@executable_path*) ;;
+                *) echo "::warning::번들 밖 rpath: ${file#"$app/"} -> $rp" ;;
+              esac
+            done < <(otool -l "$file" 2>/dev/null \
+              | awk '/LC_RPATH/{f=1} f&&/path /{print $2; f=0}')
           done < <(find "$app" -type f ! -type l)
           [ "$bad" -eq 0 ] || exit 1
           echo "OK: 외부 절대경로 0건"
@@ -129,13 +143,43 @@ jobs:
           fi
           echo "OK: 개인 자료 0건"
 
-      - name: OS 하한이 선언값과 맞는지
+      - name: 번들이 실제로 실행되는지 (연기 시험)
+        # 파일만 뒤지는 검사로는 "인터프리터가 실제로 뜨는가" 를 못 본다.
+        # desktop_cat.py 는 최상단에서 brain → psutil·openai·pydantic 을,
+        # vision_theme → Pillow·numpy 를 import 하므로, 8초를 버틴다는 것은
+        # 그 사슬이 전부 성공했다는 뜻이다.
+        run: |
+          set -euo pipefail
+          export MEMORY_CAT_HOME="$RUNNER_TEMP/smoke"
+          mkdir -p "$MEMORY_CAT_HOME"
+          "dist/Memory Cat.app/Contents/MacOS/MemoryCat" \
+            > "$RUNNER_TEMP/smoke.log" 2>&1 &
+          pid=$!
+          sleep 8
+          if ! kill -0 "$pid" 2>/dev/null; then
+            echo "::error::번들이 8초를 못 버텼습니다"
+            cat "$RUNNER_TEMP/smoke.log"
+            exit 1
+          fi
+          kill "$pid" 2>/dev/null || true
+          echo "OK: 8초 생존"
+          # stderr 에 뭐가 찍혔으면 알린다(죽지는 않았어도 알아야 한다).
+          if [ -s "$RUNNER_TEMP/smoke.log" ]; then
+            echo "::warning::실행 중 출력이 있었습니다:"
+            cat "$RUNNER_TEMP/smoke.log"
+          fi
+
+      - name: OS 하한·번들 내용물 검증
         # 번들 안 모든 Mach-O 의 minos 를 읽어 가장 높은 값과 Info.plist 의
-        # LSMinimumSystemVersion 을 대조한다. 낮게 적으면 그 사이 macOS 에서
-        # 조용히 죽는다. 러너 인터프리터가 하한을 올리면 여기서 걸린다.
+        # LSMinimumSystemVersion 이 **정확히 같은지** 본다. 낮으면 그 사이
+        # macOS 에서 조용히 죽고, 높으면 멀쩡한 맥에서 안 열린다. 러너
+        # 인터프리터가 하한을 바꾸면 여기서 걸린다.
+        # 기본 테마가 실제로 들어갔는지도 같이 본다.
+        # REQUIRE_BUNDLE=1: 번들을 못 찾으면 건너뛰지 말고 실패하라.
         run: |
           set -euo pipefail
           MEMORY_CAT_BUNDLE="dist/Memory Cat.app" \
+          MEMORY_CAT_REQUIRE_BUNDLE=1 \
             ./.venv/bin/python -m pytest -q \
             tests/test_macos_bundle.py::BuiltBundleFloorTests
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,10 @@ cat.log
 # 빌드 / 배포 산출물
 build/
 dist/
+# PyInstaller 가 자동 생성하는 스펙은 버린다. 릴리스 빌드에 쓰는
+# macos/memorycat.spec 은 손으로 쓴 소스라 예외로 둔다.
 *.spec
+!macos/memorycat.spec
 *.zip
 
 # 작업용 원본 이미지 (사용자가 직접 넣음)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,53 @@ deleted.
 | Madness | A sparkly, wide-eyed chibi cat |
 | Wake-up call | An intentionally derpy reminder to check your drive |
 
+## Download
+
+Prebuilt builds live on the [releases page](https://github.com/hyeonheebee/memory-cat/releases/latest).
+Nothing to install — unzip and run.
+
+| | File | Notes |
+|---|---|---|
+| macOS (Apple Silicon) | `Memory-Cat-macOS-AppleSilicon.zip` | macOS 11 or later |
+| macOS (Intel) | `Memory-Cat-macOS-Intel.zip` | macOS 11 or later |
+| Windows | `MemoryCat.exe` | x64. No AI features — and no network requests at all |
+
+Prefer to build it yourself, or want it to start automatically at login?
+Use [Install on macOS](#install-on-macos) below instead.
+
+### macOS will refuse to open it the first time
+
+These builds are **not code-signed** — I have no Apple Developer certificate.
+macOS therefore cannot verify them and blocks the first launch. The app is fine;
+macOS just has no way to know that. Verify the SHA-256 in the release notes if
+you want to be sure you got the file I published.
+
+**On macOS 15 (Sequoia) and later**, the dialog offers only *Done* and *Move to
+Trash* — right-clicking and choosing *Open* no longer works. Do this instead:
+
+1. Double-click the app once and press **Done** on the warning.
+2. Open **System Settings → Privacy & Security**, scroll to the bottom.
+3. Next to *"Memory Cat" was blocked*, press **Open Anyway**.
+
+That entry only appears right after a blocked launch, so do step 1 first.
+
+**On macOS 11–14**, right-click the app and choose **Open**, then **Open** again
+in the dialog.
+
+You only have to do this once.
+
+### Removing a downloaded build
+
+Move the app to the Trash. Your settings and any themes you made stay in
+`~/Library/Application Support/Memory Cat/` — delete that folder too if you want
+them gone. (Downloaded builds do not register a login item, so there is nothing
+else to clean up. The `uninstall_mac.command` mentioned below is only for
+installs made by `install_mac.command`.)
+
 ## Install on macOS
+
+This path builds the app from source on your own machine and sets it to start
+at login. It also works on Intel Macs and does not trip the warning above.
 
 ```bash
 git clone https://github.com/hyeonheebee/memory-cat.git
@@ -223,12 +269,22 @@ term:
 > positive (a `--onefile` binary unpacks itself into a temp folder at startup,
 > which resembles malware behaviour). That is expected here, but **please do not
 > learn to click through unsigned-binary warnings in general** — it is a
-> genuinely dangerous habit. Do not run a `MemoryCat.exe` you got from anyone
-> else; there is no way to verify it was built from this repository. If you want
-> assurance, skip the executable and run the Python script directly:
-> `windows/windows_cat.pyw` is a single readable file you can inspect before
-> running it. Building the `.exe` yourself, on your own machine, is the only
-> use it is recommended for.
+> genuinely dangerous habit. Do not run a `MemoryCat.exe` that reached you by
+> any other route — a forwarded file, a mirror, a chat attachment — because
+> there is no way to tell it was built from this repository.
+>
+> The build on this repository's [releases page](https://github.com/hyeonheebee/memory-cat/releases/latest)
+> is the one exception, and only if you check it: each release note publishes
+> the SHA-256 of the file, so compare it before running.
+>
+> ```powershell
+> Get-FileHash .\MemoryCat.exe -Algorithm SHA256
+> ```
+>
+> If you would rather not trust any binary, skip the executable and run the
+> Python script directly: `windows/windows_cat.pyw` is a single readable file
+> you can inspect before running it. Building the `.exe` yourself, on your own
+> machine, is always the safest option.
 
 ## Make your own theme 🎨
 
@@ -279,6 +335,10 @@ Code-generated built-in themes can be rebuilt with `python generate_frames.py`.
 desktop_cat.py      macOS desktop app and menus (PyObjC)
 apppaths.py         where bundled assets end and user data begins
 macos/build_app.py  assembles Memory Cat.app and the LaunchAgent plist
+                    (local install; the bundle it makes needs the Python it
+                    was built with)
+macos/memorycat.spec  PyInstaller spec for the release zips (self-contained:
+                    Python and every dependency live inside the bundle)
 brain.py            GPT-5.6 performance diagnosis and safe Trash workflow
 personality.py      personality presets and custom prompt compiler
 i18n.py             English/Korean UI strings and chonk-stage names

--- a/apppaths.py
+++ b/apppaths.py
@@ -17,6 +17,7 @@
 """
 
 import os
+import sys
 from pathlib import Path
 
 APP_NAME = "Memory Cat"
@@ -28,7 +29,25 @@ BUNDLED_THEMES = ("cute", "simple", "madness", "derpy")
 #: 사용자 데이터 위치를 통째로 옮기고 싶을 때 쓰는 탈출구(주로 테스트용).
 HOME_ENV = "MEMORY_CAT_HOME"
 
-_SOURCE_DIR = Path(__file__).resolve().parent
+def _resolve_source_dir() -> Path:
+    """소스와 기본 테마가 놓인 폴더를 정한다.
+
+    PyInstaller 로 묶은 릴리스 번들(:file:`macos/memorycat.spec`)에서는 이 모듈이
+    아카이브 안에 들어가서 ``__file__`` 이 실제 파일을 가리키지 않는다. 그때는
+    PyInstaller 가 풀어 놓은 폴더(``sys._MEIPASS``)에 ``frames/`` 가 있다.
+
+    저장소에서 그냥 실행할 때와 ``install_mac.command`` 가 만든 번들
+    (:file:`macos/build_app.py`, 소스를 .py 그대로 넣는다)에서는 종전대로
+    이 파일 옆을 본다.
+    """
+    if getattr(sys, "frozen", False):
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            return Path(meipass).resolve()
+    return Path(__file__).resolve().parent
+
+
+_SOURCE_DIR = _resolve_source_dir()
 
 
 def source_dir() -> Path:

--- a/macos/build_app.py
+++ b/macos/build_app.py
@@ -50,7 +50,9 @@ import apppaths  # noqa: E402
 EXECUTABLE_NAME = "MemoryCat"
 INTERPRETER_NAME = "MemoryCatPython"
 PYTHON_HOME_FILE = "pythonhome"
-VERSION = "1.0.0"
+# 릴리스 빌드(macos/memorycat.spec)와 같은 값이어야 한다. 두 경로가 서로 다른
+# 버전을 새기면 사용자가 어느 쪽으로 설치했는지 구별할 수 없다.
+VERSION = "0.2.0"
 
 #: 번들 안에서의 아이콘 파일 이름. ``CFBundleIconFile`` 에 이 값이 그대로
 #: 들어간다. 확장자를 붙여 둔다 — 애플 문서가 허용하는 형태고(크롬도

--- a/macos/memorycat.spec
+++ b/macos/memorycat.spec
@@ -134,11 +134,18 @@ app = BUNDLE(  # noqa: F821
         "CFBundleDisplayName": "Memory Cat",
         "CFBundleShortVersionString": VERSION,
         "CFBundleVersion": VERSION,
-        # 바이너리의 LC_BUILD_VERSION minos 와 반드시 같이 움직인다.
-        # 이 키가 없으면 하한 미만 macOS 에서 Launch Services 가 막지 않고 그냥
-        # 띄우고, dyld 가 프로세스를 즉시 죽인다. LSUIElement 라 창도 에러도
-        # 안 뜨는 "조용한 무반응" 이 된다 — v0.1.0 과 똑같은 증상.
-        # 값을 바꿀 때는 `vtool -show-build Contents/MacOS/MemoryCat` 로 확인한다.
+        # 번들 전체의 하한은 **가장 높은 minos 를 요구하는 바이너리** 가 정한다.
+        # 이 값을 낮게 적으면 그 사이 macOS 에서 Launch Services 가 막지 않고
+        # 그냥 띄우고, dyld 가 프로세스를 죽인다. LSUIElement 라 창도 에러도
+        # 안 뜨는 "조용한 무반응" — v0.1.0 을 못 쓰게 만든 그 증상이다.
+        #
+        # 부트로더(Contents/MacOS/MemoryCat) 하나만 보면 안 된다. 그건 번들에서
+        # 가장 낮은 값을 갖기 때문에 무슨 값을 적어도 통과한다. 하한을 올리는
+        # 것은 대개 파이썬 본체와 그 표준 라이브러리 .so 들이다.
+        #
+        # 확인은 tests/test_macos_bundle.py 의 BuiltBundleFloorTests 가 한다.
+        # 빌드 후 반드시 돌린다:
+        #     MEMORY_CAT_BUNDLE="dist/Memory Cat.app" python -m pytest -q
         "LSMinimumSystemVersion": "11.0",
         # 독에 아이콘을 띄우지 않는 배경 앱. 바탕화면 위 고양이가 본체다.
         "LSUIElement": True,

--- a/macos/memorycat.spec
+++ b/macos/memorycat.spec
@@ -25,13 +25,25 @@
 깨져서("bundle format is ambiguous") macOS 가 "손상되었기 때문에 열 수
 없습니다" 를 띄운다. arm64 는 서명 없이는 실행 자체가 안 되므로 치명적이다.
 
-빌드에 쓰는 인터프리터가 곧 번들에 들어가는 인터프리터다. Homebrew
-python@3.12 의 **framework 빌드**로 빌드해야 한다 (`--enable-framework` 없이
-빌드된 파이썬은 .app 안에서 GUI 세션을 못 잡는다).
+빌드 후 반드시 검사한다(선언한 OS 하한이 실물과 맞는지 등):
+
+    MEMORY_CAT_BUNDLE="dist/Memory Cat.app" MEMORY_CAT_REQUIRE_BUNDLE=1 \
+        python -m pytest -q
+
+`MEMORY_CAT_REQUIRE_BUNDLE=1` 을 빼면 번들을 못 찾았을 때 조용히 건너뛴다.
+릴리스를 구울 때는 반드시 건다.
+
+빌드에 쓰는 인터프리터가 곧 번들에 들어가는 인터프리터다. **Homebrew 파이썬
+으로 구우면 안 된다** — Homebrew 는 병(bottle)을 빌드하는 기계의 OS 기준으로
+굽기 때문에, Sequoia 에서 설치했으면 minos 15.0 이 박히고 그게 그대로 앱의
+하한이 된다. macOS 11~14 사용자는 앱이 조용히 죽는다. python.org 설치본의
+`macos11` 접미사 파일(framework 빌드, minos 11.0)을 쓴다. 이유와 굽는 순서는
+`requirements-release.txt` 에 적어 두었다.
 
 아키텍처는 빌드하는 기계를 따른다. universal2 는 만들지 않는다 —
 psutil·Pillow·jiter 에 universal2 휠이 없어서 어차피 한쪽만 들어간다.
-Intel 용이 필요하면 Intel 러너에서 이 스펙을 그대로 한 번 더 돌린다.
+Intel 용이 필요하면 Intel 러너에서 이 스펙을 그대로 한 번 더 돌린다
+(`.github/workflows/build-intel-mac.yml`).
 """
 
 import sys
@@ -45,8 +57,14 @@ VERSION = "0.2.0"
 
 # 기본 테마 목록은 apppaths 가 단일 진실 원천이다. 여기에 베껴 적으면 한쪽만
 # 고쳤을 때 조용히 어긋난다(기본 테마를 추가했는데 번들에 안 들어가는 식).
+# PyInstaller 는 스펙을 빌드 프로세스 안에서 exec 한다. 경로를 얹은 채로
+# 두면 이후 훅이 `metrics`/`i18n` 같은 흔한 이름을 import 할 때 저장소 모듈이
+# 이겨 버린다. import 하자마자 되돌린다(Analysis 는 pathex 로 따로 받는다).
 sys.path.insert(0, str(REPO))
-import apppaths  # noqa: E402  (위에서 경로를 얹은 뒤에야 import 된다)
+try:
+    import apppaths  # noqa: E402  (위에서 경로를 얹은 뒤에야 import 된다)
+finally:
+    sys.path.remove(str(REPO))
 
 BUNDLED_THEMES = apppaths.BUNDLED_THEMES
 

--- a/macos/memorycat.spec
+++ b/macos/memorycat.spec
@@ -1,0 +1,153 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""릴리스용 자립 번들 스펙 (PyInstaller).
+
+`macos/build_app.py` 와 역할이 다르다. 둘을 헷갈리면 안 된다.
+
+* ``build_app.py`` — **로컬 설치용**. `install_mac.command` 가 그 맥에서 만든
+  venv 와 그 맥의 인터프리터를 조립한다. 결과물은 만든 맥에서만 돈다
+  (인터프리터가 원본 프레임워크를 절대경로로 물고, 표준 라이브러리도 거기서
+  빌려 쓴다). 설치 도구로서는 이게 맞고, 그대로 둔다.
+* ``memorycat.spec`` (이 파일) — **배포용**. 파이썬 본체·표준 라이브러리·확장
+  모듈을 전부 번들 안에 넣는다. 받는 쪽에 파이썬이 없어도 실행된다.
+
+빌드:
+
+    python -m PyInstaller --noconfirm --clean macos/memorycat.spec
+
+포장 — **반드시 ditto 로 한다**:
+
+    ditto -c -k --sequesterRsrc --keepParent \
+        "dist/Memory Cat.app" "Memory-Cat-macOS-AppleSilicon.zip"
+
+`zip -r` 를 쓰면 안 된다. 이 번들은 `Contents/Resources/*` 대부분이
+`../Frameworks/*` 로 가는 심볼릭 링크인데, `zip -r` 은 링크를 따라가서 실체를
+복사한다. 그러면 크기가 커질 뿐 아니라 PyInstaller 가 붙여 둔 ad-hoc 서명이
+깨져서("bundle format is ambiguous") macOS 가 "손상되었기 때문에 열 수
+없습니다" 를 띄운다. arm64 는 서명 없이는 실행 자체가 안 되므로 치명적이다.
+
+빌드에 쓰는 인터프리터가 곧 번들에 들어가는 인터프리터다. Homebrew
+python@3.12 의 **framework 빌드**로 빌드해야 한다 (`--enable-framework` 없이
+빌드된 파이썬은 .app 안에서 GUI 세션을 못 잡는다).
+
+아키텍처는 빌드하는 기계를 따른다. universal2 는 만들지 않는다 —
+psutil·Pillow·jiter 에 universal2 휠이 없어서 어차피 한쪽만 들어간다.
+Intel 용이 필요하면 Intel 러너에서 이 스펙을 그대로 한 번 더 돌린다.
+"""
+
+import sys
+from pathlib import Path
+
+# 스펙 파일에는 __file__ 이 없다. PyInstaller 가 넣어 주는 SPECPATH 를 쓴다.
+REPO = Path(SPECPATH).resolve().parent  # noqa: F821  (SPECPATH is injected)
+
+# 릴리스 태그와 반드시 같이 움직여야 하는 값. 태그를 올리면 여기도 올린다.
+VERSION = "0.2.0"
+
+# 기본 테마 목록은 apppaths 가 단일 진실 원천이다. 여기에 베껴 적으면 한쪽만
+# 고쳤을 때 조용히 어긋난다(기본 테마를 추가했는데 번들에 안 들어가는 식).
+sys.path.insert(0, str(REPO))
+import apppaths  # noqa: E402  (위에서 경로를 얹은 뒤에야 import 된다)
+
+BUNDLED_THEMES = apppaths.BUNDLED_THEMES
+
+# `frames/` 에는 개발 중 만든 개인 테마(mypet*, gandi-* 등 — 실제 반려동물 사진이
+# 들어간다)와 추적하지 않는 잡파일(_preview.png)이 같이 쌓인다. 공개 배포물에
+# 그게 섞이면 되돌릴 수 없으므로, 폴더를 통째로 넣지 않고 **테마별로 실제 쓰는
+# 프레임 파일만** 골라 넣는다.
+#
+# 검사는 assert 로 하지 않는다. `python -O` 로 빌드하면 assert 가 통째로
+# 사라져서, 개인 사진 유출 방어선이 인터프리터 플래그 하나로 꺼져 버린다.
+datas = []
+for _theme in BUNDLED_THEMES:
+    _src = REPO / "frames" / _theme
+    if not _src.is_dir():
+        raise SystemExit(f"기본 테마 {_theme} 가 없다: {_src}")
+    _frames = sorted(_src.glob("cat_*.png"))
+    if not _frames:
+        raise SystemExit(f"기본 테마 {_theme} 에 cat_*.png 가 없다: {_src}")
+    for _png in _frames:
+        datas.append((str(_png), f"frames/{_theme}"))
+
+# 배포물에도 라이선스 원문을 넣는다(MIT 요구사항).
+datas.append((str(REPO / "LICENSE"), "."))
+
+
+a = Analysis(  # noqa: F821
+    [str(REPO / "desktop_cat.py")],
+    pathex=[str(REPO)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    # 안 쓰는 GUI/과학 스택이 딸려 들어가면 번들만 커진다.
+    excludes=["tkinter", "matplotlib", "pytest", "setuptools", "pip"],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)  # noqa: F821
+
+exe = EXE(  # noqa: F821
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    # 이 이름이 그대로 CFBundleExecutable 이 된다(PyInstaller building/osx.py).
+    # `build_app.py` 번들과 반드시 같아야 한다: install_mac.command 가 등록한
+    # LaunchAgent 가 `Contents/MacOS/MemoryCat` 을 절대경로로 가리키고 있어서,
+    # 이름을 바꾸면 기존 설치자가 새 번들로 덮어썼을 때 로그인 시 실행이
+    # 조용히 실패한다(KeepAlive 가 60초마다 재시도만 반복).
+    # 사용자에게 보이는 이름은 CFBundleName/CFBundleDisplayName 이라 영향 없다.
+    name="MemoryCat",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,  # LSUIElement 와 별개로, 터미널 창을 띄우지 않는다.
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,  # 빌드하는 기계의 아키텍처
+    codesign_identity=None,  # 미서명. 릴리스 노트에서 우회법을 안내한다.
+    entitlements_file=None,
+)
+
+coll = COLLECT(  # noqa: F821
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="Memory Cat",
+)
+
+app = BUNDLE(  # noqa: F821
+    coll,
+    name="Memory Cat.app",
+    icon=str(REPO / "macos" / "MemoryCat.icns"),
+    bundle_identifier="com.memorycat.desktop",
+    version=VERSION,
+    info_plist={
+        "CFBundleName": "Memory Cat",
+        "CFBundleDisplayName": "Memory Cat",
+        "CFBundleShortVersionString": VERSION,
+        "CFBundleVersion": VERSION,
+        # 바이너리의 LC_BUILD_VERSION minos 와 반드시 같이 움직인다.
+        # 이 키가 없으면 하한 미만 macOS 에서 Launch Services 가 막지 않고 그냥
+        # 띄우고, dyld 가 프로세스를 즉시 죽인다. LSUIElement 라 창도 에러도
+        # 안 뜨는 "조용한 무반응" 이 된다 — v0.1.0 과 똑같은 증상.
+        # 값을 바꿀 때는 `vtool -show-build Contents/MacOS/MemoryCat` 로 확인한다.
+        "LSMinimumSystemVersion": "11.0",
+        # 독에 아이콘을 띄우지 않는 배경 앱. 바탕화면 위 고양이가 본체다.
+        "LSUIElement": True,
+        "NSHighResolutionCapable": True,
+        # 아래 세 개는 build_app.py 번들과 파리티를 맞추려고 유지한다.
+        "CFBundleDevelopmentRegion": "ko",
+        "NSSupportsAutomaticTermination": False,
+        "NSSupportsSuddenTermination": False,
+        "LSApplicationCategoryType": "public.app-category.utilities",
+        "NSHumanReadableCopyright": "Copyright (c) 2026 Hyeonhee Shim. MIT License.",
+    },
+)

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,0 +1,13 @@
+# 릴리스 zip 을 굽는 데만 필요한 것. 앱 실행에는 필요 없다.
+#
+#   python3.12 -m venv .relvenv
+#   .relvenv/bin/pip install -r requirements.txt -r requirements-release.txt
+#   .relvenv/bin/python -m PyInstaller --noconfirm --clean macos/memorycat.spec
+#
+# 빌드에 쓰는 인터프리터가 곧 번들에 들어가는 인터프리터다. Homebrew
+# python@3.12 의 framework 빌드를 쓴다. 자세한 내용은 macos/memorycat.spec.
+#
+# 상한(<7)은 requirements.txt 와 같은 이유다 — 메이저 업그레이드가 예고 없이
+# 릴리스 빌드를 바꾸면 안 된다. 하한은 실제로 검증한 가장 오래된 버전.
+# v0.2.0 은 6.22.2 로 구웠다.
+pyinstaller>=6.20,<7

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,13 +1,47 @@
-# 릴리스 zip 을 굽는 데만 필요한 것. 앱 실행에는 필요 없다.
+# 릴리스 zip 을 굽는 데만 필요한 것. 앱 실행에도, 개발에도 필요 없다.
 #
-#   python3.12 -m venv .relvenv
-#   .relvenv/bin/pip install -r requirements.txt -r requirements-release.txt
+# ─────────────────────────────────────────────────────────────────────
+# 어떤 파이썬으로 굽느냐가 "누가 이 앱을 쓸 수 있는가" 를 정한다
+# ─────────────────────────────────────────────────────────────────────
+# PyInstaller 는 빌드에 쓴 인터프리터를 번들 안으로 **복사한다**. 그래서 굽는
+# 사람 맥에 파이썬이 있느냐가 아니라, 상자에 어떤 부품이 들어가느냐의 문제다.
+# 파이썬 바이너리에 새겨진 최소 macOS(minos)가 그대로 앱의 하한이 된다.
+#
+#   Homebrew python@3.12   minos 15.0   arm64            ← 쓰면 안 된다
+#   python.org  3.12.10    minos 11.0   x86_64 + arm64   ← 이걸 쓴다
+#
+# Homebrew 는 병(bottle)을 빌드하는 기계의 OS 기준으로 굽는다. Sequoia 에서
+# 설치했으면 "macOS 15 이상" 이 박히고, 그게 복사되어 macOS 11~14 사용자는
+# 앱이 조용히 죽는다(LSUIElement 라 창도 에러도 안 뜬다). v0.2.0 을 준비하며
+# 실제로 이 함정에 한 번 빠졌다.
+#
+# python.org 설치본(https://www.python.org/downloads/macos/)의 `macos11` 접미사
+# 파일을 쓴다. 3.12 는 3.12.10 이 바이너리 설치본이 있는 마지막 버전이다
+# (이후 보안 릴리스는 소스만 배포된다).
+#
+# ─────────────────────────────────────────────────────────────────────
+# 릴리스 굽는 순서
+# ─────────────────────────────────────────────────────────────────────
+#   /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 \
+#       -m venv .relvenv
+#   .relvenv/bin/pip install -r requirements.txt "numpy<2" \
+#       -r requirements-release.txt
 #   .relvenv/bin/python -m PyInstaller --noconfirm --clean macos/memorycat.spec
 #
-# 빌드에 쓰는 인터프리터가 곧 번들에 들어가는 인터프리터다. Homebrew
-# python@3.12 의 framework 빌드를 쓴다. 자세한 내용은 macos/memorycat.spec.
+#   # 하한이 실제로 맞는지 반드시 확인한다. 이 검사가 없으면 조용히 틀린다.
+#   MEMORY_CAT_BUNDLE="dist/Memory Cat.app" python -m pytest -q
 #
+#   # 포장은 ditto 로. zip -r 은 ad-hoc 서명을 깨뜨린다.
+#   ditto -c -k --sequesterRsrc --keepParent \
+#       "dist/Memory Cat.app" "Memory-Cat-macOS-AppleSilicon.zip"
+#
+# ─────────────────────────────────────────────────────────────────────
+
 # 상한(<7)은 requirements.txt 와 같은 이유다 — 메이저 업그레이드가 예고 없이
 # 릴리스 빌드를 바꾸면 안 된다. 하한은 실제로 검증한 가장 오래된 버전.
-# v0.2.0 은 6.22.2 로 구웠다.
 pyinstaller>=6.20,<7
+
+# numpy 2.x 의 arm64 휠은 macOS 14 를 요구한다. 앱은 requirements.txt 에서
+# >=1.24,<3 을 허용하므로, 릴리스 빌드에서만 1.x 로 낮춰 하한을 11.0 으로
+# 유지한다. 개발·소스 설치는 2.x 를 그대로 써도 된다.
+numpy<2

--- a/tests/test_macos_bundle.py
+++ b/tests/test_macos_bundle.py
@@ -581,8 +581,13 @@ def macho_minos(blob):
         return None
     magic = struct.unpack("<I", blob[:4])[0]
     if magic in FAT_MAGICS:
-        # universal 바이너리. 이 저장소는 단일 아키텍처만 굽는다.
-        return None
+        # universal 바이너리. 이 저장소는 아키텍처 하나씩만 굽는다(휠에
+        # universal2 가 없다). 여기서 None 을 돌려주면 그 파일의 minos 가
+        # 검사에서 통째로 사라지므로, 조용히 넘기지 않고 알린다.
+        raise ValueError(
+            "fat(universal) 바이너리는 아직 검사할 수 없습니다. "
+            "슬라이스별 minos 를 읽도록 이 함수를 고쳐야 합니다."
+        )
     if magic == MH_MAGIC_64:
         endian = "<"
     elif magic == MH_CIGAM_64:
@@ -627,6 +632,11 @@ class BuiltBundleFloorTests(unittest.TestCase):
     #: 빌드 산출물 위치. `--distpath` 를 다른 데로 줬으면 이 환경변수로 알린다.
     BUNDLE_ENV = "MEMORY_CAT_BUNDLE"
 
+    #: 1 이면 번들이 없을 때 건너뛰지 않고 실패한다. 릴리스를 구울 때 이걸
+    #: 걸어야 한다 — 그러지 않으면 `--distpath` 를 옮긴 순간 이 검사들이
+    #: 통째로 조용히 사라지고, 아무도 모르는 채로 zip 이 나간다.
+    REQUIRE_ENV = "MEMORY_CAT_REQUIRE_BUNDLE"
+
     def setUp(self):
         override = os.environ.get(self.BUNDLE_ENV)
         self.bundle = (
@@ -635,10 +645,13 @@ class BuiltBundleFloorTests(unittest.TestCase):
             else _REPO / "dist" / "Memory Cat.app"
         )
         if not (self.bundle / "Contents" / "Info.plist").is_file():
-            self.skipTest(
+            missing = (
                 f"빌드된 번들이 없습니다: {self.bundle} "
                 f"(다른 데 있으면 {self.BUNDLE_ENV} 로 알려주세요)"
             )
+            if os.environ.get(self.REQUIRE_ENV) == "1":
+                self.fail(f"{self.REQUIRE_ENV}=1 인데 {missing}")
+            self.skipTest(missing)
 
     def _declared(self):
         with open(self.bundle / "Contents" / "Info.plist", "rb") as handle:
@@ -668,15 +681,57 @@ class BuiltBundleFloorTests(unittest.TestCase):
                 blame.append(path)
         return highest, blame
 
-    def test_declared_floor_is_not_lower_than_the_binaries_require(self):
+    def test_declared_floor_matches_what_the_binaries_require(self):
+        """선언값은 실제 최대 minos 와 **정확히 같아야** 한다.
+
+        낮게 적으면 그 사이 macOS 에서 Launch Services 를 통과한 뒤 dyld 가
+        프로세스를 죽인다 — LSUIElement 라 창도 에러도 없다. 높게 적으면
+        반대로, 멀쩡히 돌아갈 맥에서 Launch Services 가 아예 열어 주지 않는다.
+        사용자에게는 양쪽 다 "안 켜진다" 로만 보이므로 한 방향만 보면 안 된다.
+        """
         declared = self._declared()
         actual, blame = self._actual()
         self.assertNotEqual(actual, (0, 0, 0), "Mach-O 를 하나도 못 찾았습니다")
         names = ", ".join(p.name for p in blame[:5])
-        self.assertGreaterEqual(
+        self.assertEqual(
             declared, actual,
-            f"선언한 하한 {declared} 이 실제 {actual} 보다 낮습니다. "
-            f"그 사이 macOS 에서 조용히 죽습니다. 요구한 파일: {names}",
+            f"선언한 하한 {declared} 과 실제 {actual} 이 다릅니다. 낮으면 그 사이 "
+            f"macOS 에서 조용히 죽고, 높으면 멀쩡한 맥에서 안 열립니다. "
+            f"실제 하한을 요구한 파일: {names}",
+        )
+
+    def test_bundled_themes_actually_landed(self):
+        """기본 테마가 번들 안에 실제로 있는지 본다.
+
+        스펙은 **소스** frames 가 없으면 빌드를 멈추지만 산출물은 확인하지
+        않는다. 그리고 앱이 읽는 `Contents/Frameworks/frames` 는 PyInstaller 가
+        만든 `../Resources/frames` 심볼릭 링크다 — 허용 범위 안의 PyInstaller
+        마이너 업그레이드가 이 배치를 바꾸면 링크가 사라지고 프레임을 못 읽는다.
+        LSUIElement 라 고양이가 조용히 안 뜨고, 나머지 검사는 전부 초록이다.
+        """
+        roots = [
+            self.bundle / "Contents" / "Frameworks" / "frames",
+            self.bundle / "Contents" / "Resources" / "frames",
+        ]
+        for root in roots:
+            self.assertTrue(root.is_dir(), f"번들에 frames 가 없습니다: {root}")
+            found = {child.name for child in root.iterdir() if child.is_dir()}
+            self.assertEqual(
+                found, set(apppaths.BUNDLED_THEMES),
+                f"{root} 의 테마 목록이 다릅니다. "
+                f"빠짐: {sorted(set(apppaths.BUNDLED_THEMES) - found)} / "
+                f"남는 것(개인 테마 유출일 수 있음): {sorted(found - set(apppaths.BUNDLED_THEMES))}",
+            )
+            for theme in apppaths.BUNDLED_THEMES:
+                frames = sorted((root / theme).glob("cat_*.png"))
+                self.assertTrue(frames, f"{theme} 에 cat_*.png 가 없습니다")
+
+    def test_executable_is_where_the_plist_says(self):
+        info_exe = self.bundle / "Contents" / "MacOS" / build_app.EXECUTABLE_NAME
+        self.assertTrue(
+            info_exe.is_file(),
+            f"실행 파일이 없습니다: {info_exe}. LaunchAgent 가 이 절대경로를 "
+            f"가리키므로 이름이 바뀌면 기존 설치자의 로그인 실행이 깨진다.",
         )
 
 

--- a/tests/test_macos_bundle.py
+++ b/tests/test_macos_bundle.py
@@ -11,10 +11,12 @@
    확인되는 물건이라 회귀가 조용히 지나가기 쉽다.
 """
 
+import ast
 import importlib.util
 import os
 import plistlib
 import struct
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -440,6 +442,112 @@ class AppPathsTests(unittest.TestCase):
                 candidates = apppaths.dotenv_candidates()
             self.assertEqual(candidates[0], Path(temp) / ".env")
             self.assertEqual(candidates[1], apppaths.source_dir() / ".env")
+
+
+class FrozenSourceDirTests(unittest.TestCase):
+    """``_resolve_source_dir()`` 은 세 가지 실행 형태를 모두 맞춰야 한다.
+
+    저장소 직접 실행 / ``build_app.py`` 번들(소스를 .py 그대로 넣어서 frozen 이
+    아니다) / PyInstaller 릴리스 번들(frozen, ``sys._MEIPASS``).
+    """
+
+    def test_repo_and_local_bundle_look_next_to_this_file(self):
+        expected = Path(apppaths.__file__).resolve().parent
+        with patch.object(sys, "frozen", False, create=True):
+            self.assertEqual(apppaths._resolve_source_dir(), expected)
+        # `frozen` 속성 자체가 없는 평범한 인터프리터도 같은 답이어야 한다.
+        with patch.dict(sys.__dict__):
+            sys.__dict__.pop("frozen", None)
+            self.assertEqual(apppaths._resolve_source_dir(), expected)
+
+    def test_pyinstaller_bundle_uses_meipass(self):
+        with tempfile.TemporaryDirectory() as temp:
+            meipass = Path(temp).resolve()
+            with patch.object(sys, "frozen", True, create=True), \
+                 patch.object(sys, "_MEIPASS", str(meipass), create=True):
+                self.assertEqual(apppaths._resolve_source_dir(), meipass)
+
+    def test_frozen_without_meipass_falls_back_to_this_file(self):
+        # cx_Freeze 처럼 _MEIPASS 를 안 넣는 freezer 에서 죽지 말고, 이 변경
+        # 이전과 같은 동작으로 돌아가야 한다.
+        expected = Path(apppaths.__file__).resolve().parent
+        with patch.dict(sys.__dict__), \
+                patch.object(sys, "frozen", True, create=True):
+            sys.__dict__.pop("_MEIPASS", None)
+            self.assertEqual(apppaths._resolve_source_dir(), expected)
+
+    def test_module_level_source_dir_matches_the_resolver(self):
+        # import 시점에 한 번만 계산해서 캐시한다. 함수와 어긋나면 안 된다.
+        self.assertEqual(apppaths.source_dir(), apppaths._resolve_source_dir())
+
+
+class ReleaseSpecTests(unittest.TestCase):
+    """릴리스 스펙이 기본 테마만, 그리고 전부 담는지 지킨다.
+
+    스펙이 개인 테마(``mypet*`` 등 실제 반려동물 사진)를 담으면 되돌릴 수 없고,
+    기본 테마를 빠뜨리면 사용자가 그 테마를 고른 순간 프레임을 못 읽는다.
+    """
+
+    SPEC = Path(__file__).resolve().parent.parent / "macos" / "memorycat.spec"
+
+    def test_spec_takes_the_theme_list_from_apppaths(self):
+        # 목록을 베껴 적으면 한쪽만 고쳤을 때 조용히 어긋난다.
+        source = self.SPEC.read_text(encoding="utf-8")
+        self.assertIn("BUNDLED_THEMES = apppaths.BUNDLED_THEMES", source)
+
+    def _tree(self):
+        # 주석·docstring 에 어떤 단어가 있는지는 상관없다. 실제로 실행되는
+        # 코드만 봐야 하므로 텍스트 검색이 아니라 AST 로 읽는다.
+        return ast.parse(self.SPEC.read_text(encoding="utf-8"))
+
+    def _code_strings(self):
+        return [
+            node.value
+            for node in ast.walk(self._tree())
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        ]
+
+    def test_spec_never_names_a_theme_outside_the_defaults(self):
+        # 개인 테마 이름이 코드에 들어가면 즉시 실패한다.
+        docstrings = set()
+        tree = self._tree()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Module, ast.FunctionDef, ast.ClassDef)):
+                doc = ast.get_docstring(node, clean=False)
+                if doc:
+                    docstrings.add(doc)
+        for text in self._code_strings():
+            if text in docstrings:
+                continue
+            for name in ("mypet", "gandi-", "dog-hero", "livetest"):
+                self.assertNotIn(name, text)
+
+    def test_spec_ships_only_frame_files(self):
+        # 폴더를 통째로 넣으면 추적 안 되는 잡파일(_preview.png)까지 따라간다.
+        self.assertIn("cat_*.png", self._code_strings())
+
+    def test_theme_guards_survive_python_dash_O(self):
+        # `python -O` 로 빌드하면 assert 문이 통째로 사라진다. 개인 사진 유출
+        # 방어선을 인터프리터 플래그 하나로 꺼지는 문에 두면 안 된다.
+        asserts = [n for n in ast.walk(self._tree()) if isinstance(n, ast.Assert)]
+        self.assertEqual(
+            asserts, [],
+            "스펙에 assert 가 있다. -O 빌드에서 사라지므로 raise 로 바꿔야 한다.",
+        )
+
+    def test_minimum_system_version_is_declared(self):
+        # 이 키가 없으면 하한 미만 macOS 에서 dyld 가 조용히 죽인다.
+        source = self.SPEC.read_text(encoding="utf-8")
+        self.assertIn("LSMinimumSystemVersion", source)
+
+    def test_executable_name_matches_the_local_install_bundle(self):
+        # LaunchAgent 가 Contents/MacOS/<이 이름> 을 절대경로로 가리킨다.
+        source = self.SPEC.read_text(encoding="utf-8")
+        self.assertIn(f'name="{build_app.EXECUTABLE_NAME}"', source)
+
+    def test_both_build_paths_stamp_the_same_version(self):
+        source = self.SPEC.read_text(encoding="utf-8")
+        self.assertIn(f'VERSION = "{build_app.VERSION}"', source)
 
 
 if __name__ == "__main__":

--- a/tests/test_macos_bundle.py
+++ b/tests/test_macos_bundle.py
@@ -537,6 +537,8 @@ class ReleaseSpecTests(unittest.TestCase):
 
     def test_minimum_system_version_is_declared(self):
         # 이 키가 없으면 하한 미만 macOS 에서 dyld 가 조용히 죽인다.
+        # 값이 맞는지는 BuiltBundleFloorTests 가 실물로 검사한다 — 여기서
+        # 문자열만 보고 끝내면 11.0 이든 99.0 이든 통과한다.
         source = self.SPEC.read_text(encoding="utf-8")
         self.assertIn("LSMinimumSystemVersion", source)
 
@@ -548,6 +550,134 @@ class ReleaseSpecTests(unittest.TestCase):
     def test_both_build_paths_stamp_the_same_version(self):
         source = self.SPEC.read_text(encoding="utf-8")
         self.assertIn(f'VERSION = "{build_app.VERSION}"', source)
+
+
+#: Mach-O 로드 커맨드. ``LC_BUILD_VERSION`` 이 그 바이너리가 요구하는 최소
+#: OS(minos)를 담는다. 구형 툴체인은 ``LC_VERSION_MIN_MACOSX`` 를 쓴다.
+LC_BUILD_VERSION = 0x32
+LC_VERSION_MIN_MACOSX = 0x24
+
+MH_MAGIC_64 = 0xFEEDFACF
+MH_CIGAM_64 = 0xCFFAEDFE
+FAT_MAGICS = (0xCAFEBABE, 0xBEBAFECA, 0xCAFEBABF, 0xBFBAFECA)
+
+
+def _triple(parts):
+    """버전 조각을 항상 3칸짜리 튜플로. 길이가 달라 생기는 오비교를 막는다."""
+    nums = [int(part) for part in parts][:3]
+    return tuple(nums + [0] * (3 - len(nums)))
+
+
+def macho_minos(blob):
+    """Mach-O 하나가 요구하는 최소 macOS 를 ``(major, minor, patch)`` 로.
+
+    ``vtool``/``otool`` 을 부르지 않는 이유는 이 저장소가 서브프로세스를 쓰지
+    않기 때문이다(`macos/build_app.py` 첫 docstring). 포맷은 단순하다 —
+    64비트 헤더 32바이트 뒤로 ``(cmd 4바이트, cmdsize 4바이트, 본문)`` 반복.
+
+    Mach-O 가 아니거나 버전 로드 커맨드가 없으면 ``None``.
+    """
+    if len(blob) < 32:
+        return None
+    magic = struct.unpack("<I", blob[:4])[0]
+    if magic in FAT_MAGICS:
+        # universal 바이너리. 이 저장소는 단일 아키텍처만 굽는다.
+        return None
+    if magic == MH_MAGIC_64:
+        endian = "<"
+    elif magic == MH_CIGAM_64:
+        endian = ">"
+    else:
+        return None
+
+    ncmds = struct.unpack(endian + "I", blob[16:20])[0]
+    offset = 32
+    for _ in range(ncmds):
+        if offset + 8 > len(blob):
+            return None
+        cmd, cmdsize = struct.unpack(endian + "II", blob[offset:offset + 8])
+        if cmdsize < 8:
+            return None
+        if cmd == LC_BUILD_VERSION and offset + 16 <= len(blob):
+            raw = struct.unpack(endian + "I", blob[offset + 12:offset + 16])[0]
+            return _triple((raw >> 16, (raw >> 8) & 0xFF, raw & 0xFF))
+        if cmd == LC_VERSION_MIN_MACOSX and offset + 12 <= len(blob):
+            raw = struct.unpack(endian + "I", blob[offset + 8:offset + 12])[0]
+            return _triple((raw >> 16, (raw >> 8) & 0xFF, raw & 0xFF))
+        offset += cmdsize
+    return None
+
+
+class BuiltBundleFloorTests(unittest.TestCase):
+    """빌드된 번들의 ``LSMinimumSystemVersion`` 이 실물과 맞는지 본다.
+
+    번들 전체의 하한은 **가장 높은 minos 를 요구하는 바이너리** 가 정한다.
+    이걸 낮게 적으면 그 사이 버전의 macOS 에서 Launch Services 가 막지 않고
+    그냥 띄우고, dyld 가 프로세스를 죽인다. ``LSUIElement`` 라 창도 에러도
+    없이 아무 일도 안 일어난다 — v0.1.0 을 못 쓰게 만든 바로 그 증상이다.
+
+    v0.2.0 직전에 실제로 이걸 틀렸다. 스펙에는 11.0 이라고 적혀 있었지만
+    Homebrew python@3.12 병이 Sequoia 에서 구워져서 실제 하한은 15.0 이었다.
+    부트로더(`Contents/MacOS/MemoryCat`)만 확인하면 번들에서 유일하게 11.0 인
+    놈이라 통과해 버린다. **모든** Mach-O 를 봐야 한다.
+
+    번들이 없으면 건너뛴다. 릴리스 전에는 반드시 빌드한 뒤 돌린다.
+    """
+
+    #: 빌드 산출물 위치. `--distpath` 를 다른 데로 줬으면 이 환경변수로 알린다.
+    BUNDLE_ENV = "MEMORY_CAT_BUNDLE"
+
+    def setUp(self):
+        override = os.environ.get(self.BUNDLE_ENV)
+        self.bundle = (
+            Path(override).expanduser()
+            if override
+            else _REPO / "dist" / "Memory Cat.app"
+        )
+        if not (self.bundle / "Contents" / "Info.plist").is_file():
+            self.skipTest(
+                f"빌드된 번들이 없습니다: {self.bundle} "
+                f"(다른 데 있으면 {self.BUNDLE_ENV} 로 알려주세요)"
+            )
+
+    def _declared(self):
+        with open(self.bundle / "Contents" / "Info.plist", "rb") as handle:
+            info = plistlib.load(handle)
+        raw = info.get("LSMinimumSystemVersion")
+        self.assertIsNotNone(raw, "LSMinimumSystemVersion 이 없습니다")
+        # "15" / "15.0" / "15.0.0" 이 다 같은 값이어야 한다. 길이가 다른 튜플을
+        # 그냥 비교하면 (15, 0) < (15, 0, 0) 이라 맞는 값도 실패한다.
+        return _triple(str(raw).split("."))
+
+    def _actual(self):
+        """번들 안 모든 Mach-O 중 가장 높은 minos 와, 그걸 요구한 파일들."""
+        highest = (0, 0, 0)
+        blame = []
+        for path in sorted(self.bundle.rglob("*")):
+            if not path.is_file() or path.is_symlink():
+                continue
+            try:
+                minos = macho_minos(path.read_bytes())
+            except OSError:
+                continue
+            if minos is None:
+                continue
+            if minos > highest:
+                highest, blame = minos, [path]
+            elif minos == highest:
+                blame.append(path)
+        return highest, blame
+
+    def test_declared_floor_is_not_lower_than_the_binaries_require(self):
+        declared = self._declared()
+        actual, blame = self._actual()
+        self.assertNotEqual(actual, (0, 0, 0), "Mach-O 를 하나도 못 찾았습니다")
+        names = ", ".join(p.name for p in blame[:5])
+        self.assertGreaterEqual(
+            declared, actual,
+            f"선언한 하한 {declared} 이 실제 {actual} 보다 낮습니다. "
+            f"그 사이 macOS 에서 조용히 죽습니다. 요구한 파일: {names}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 왜

v0.1.0 의 macOS zip 은 **빌드한 맥에서만 실행된다.** 번들 안 인터프리터가 Homebrew python@3.14 를 절대경로로 물고, 파이썬 표준 라이브러리도 번들에 없이 그 프레임워크에서 빌려 쓴다. 그 파이썬이 없는 맥에서는 dyld 단계에서 죽는데, `LSUIElement=true` 라 **창도 에러도 없이 아무 일도 일어나지 않는다.**

원인은 빌드 도구를 용도 밖으로 쓴 것이다. `macos/build_app.py` 는 `install_mac.command` 가 그 맥에서 만든 venv 와 그 맥의 인터프리터를 조립하는 **로컬 설치 도구**다. 설치 도구로서는 옳으므로 그대로 두고, 릴리스 전용 경로를 따로 냈다.

릴리스 다운로드 수가 macOS 0회 / Windows 1회인 것도 이 맥락에서 봐야 한다.

## 무엇을

- **`macos/memorycat.spec`** (신규) — PyInstaller 스펙. 파이썬 본체·표준 라이브러리·확장 모듈을 전부 번들에 넣는다.
- **릴리스는 python.org 인터프리터로 굽는다.** Homebrew 는 병을 빌드하는 기계의 OS 기준으로 굽기 때문에, Sequoia 에서 설치했으면 minos 15.0 이 박혀 macOS 11~14 사용자가 조용히 죽는다. 실제로 첫 빌드가 이 함정에 빠졌다. numpy 도 2.x arm64 휠이 macOS 14 를 요구해서 릴리스 빌드에서만 1.x 로 낮춘다.
- **`apppaths.py`** — frozen 일 때 `sys._MEIPASS` 를 본다. 저장소 직접 실행과 `build_app.py` 번들은 종전대로 동작한다(둘 다 frozen 이 아니다).
- **인텔 CI 수정** — 기존 워크플로가 인텔 zip 을 `build_app.py` 로 구웠다. 같은 결함을 인텔 사용자에게 내보내는 구조였고, `on: release: published` 라 릴리스 발행 순간 자동 첨부된다. 스펙 경로로 바꾸고 자립성·하한·연기 시험을 넣었다.
- **README** — 릴리스 zip 얘기가 한 줄도 없었다. Download 절을 추가하고, macOS 15 부터 "우클릭 → 열기" 가 통하지 않는다는 것과 시스템 설정 경로를 적었다.

## 결과

| | 이전 | 이후 |
|---|---|---|
| 실행 조건 | Homebrew python@3.14 필요 | 없어도 됨 |
| 지원 macOS | 15 전용 (선언은 11.0 이었음) | **11 이상** (실측 일치) |
| Homebrew 참조 | 하드코딩 | 0건 |
| 테스트 | 155 | **169** |

## 검증

- 번들 안 Mach-O 108개 전부 minos 11.0, 외부 절대경로 0건, 개인 테마·`.env` 0건
- `DYLD_PRINT_LIBRARIES` 로 실제 로드된 687개 중 번들 밖은 `/usr/lib`·`/System` 뿐
- 기본 테마 PNG 160장을 픽셀 해시로 개인 테마 588장과 대조 → 일치 0건
- ditto 왕복 후 서명 유효. `zip -r` 은 서명을 깨뜨려서 쓰면 안 된다(스펙에 명시)
- 새 검사 5가지를 일부러 뚫어 전부 걸리는 것 확인: 하한을 높게/낮게 적기, 기본 테마 삭제, 개인 테마 혼입, 실행 파일 이름 변경, 번들 없이 REQUIRE=1

## 남은 것

인텔 워크플로는 아직 실행해 본 적이 없다. `workflow_dispatch` 가 기본 브랜치의 파일만 보므로 **이 PR 을 머지한 뒤 수동 실행해서 인텔 zip 실물을 확인해야 한다.** 확인 전에는 릴리스를 발행하지 말 것 — 발행 순간 자동 첨부된다.

setup-python 이 설치하는 파이썬은 python.org `python-3.12.10-macos11.pkg` 와 바이트 동일함을 확인했다(sha256 `14e61fb2…`, minos 11.0). 인텔 zip 하한도 11.0 이 나올 것으로 본다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)