### PR TITLE
윈도우 exe 도 Actions 에서 굽는다

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,128 @@
+name: Build Windows app
+
+# 윈도우 exe 는 윈도우에서만 구울 수 있다. 지금까지는 사람이 자기 PC 에서
+# 구워 릴리스에 올렸는데, 그러면 두 가지가 걸린다.
+#
+#   1. 코드를 한 줄 고쳐도 그 PC 가 있어야 릴리스가 나간다.
+#   2. 받는 사람이 그 exe 를 검증할 방법이 없다. README 가 "출처를 확인할 수
+#      없는 MemoryCat.exe 는 실행하지 마세요" 라고 적어 두었는데, 릴리스에
+#      올린 파일이 바로 그런 파일이 되어 버린다.
+#
+# 여기서 구우면 커밋 → 빌드 로그 → 산출물이 공개로 이어진다. 받는 사람은
+# 릴리스 노트의 SHA-256 과 대조해서 "이 커밋에서 나온 파일" 임을 확인할 수 있다.
+#
+# 빌드 자체는 `windows/build_exe.bat` 을 그대로 부른다. PyInstaller 인자를
+# 여기에 베껴 적으면 둘이 조용히 어긋난다 — 사람이 손으로 굽는 경로와
+# CI 가 굽는 경로가 달라지는 것이 이 저장소가 이미 한 번 겪은 사고다.
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 의존성 설치
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          # windows/requirements.txt = PySide6, psutil (맥판과 완전히 별개 구현)
+          python -m pip install -r windows/requirements.txt
+          python -m pip install "pyinstaller>=6.20,<7"
+
+      - name: exe 굽기
+        shell: cmd
+        # `< nul` 이 필요하다. build_exe.bat 은 사람이 더블클릭해서 쓰는
+        # 스크립트라 끝과 오류 지점마다 `pause` 가 있는데, CI 에서는 그게
+        # 키 입력을 기다리며 잡을 멈춰 세운다. stdin 을 nul 로 돌리면
+        # pause 가 즉시 반환한다.
+        run: windows\build_exe.bat < nul
+
+      - name: 산출물 검증
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $exe = 'windows\dist\MemoryCat.exe'
+
+          if (-not (Test-Path $exe)) {
+            Write-Error "::error::exe 가 안 만들어졌습니다: $exe"
+            exit 1
+          }
+
+          # PE(윈도우 실행 파일) 매직 'MZ' 확인. 빌드가 반쯤 실패하고
+          # 껍데기만 남는 경우를 거른다.
+          $head = [System.IO.File]::ReadAllBytes($exe)[0..1]
+          if ($head[0] -ne 0x4D -or $head[1] -ne 0x5A) {
+            Write-Error "::error::PE 실행 파일이 아닙니다"
+            exit 1
+          }
+
+          # --onefile 이라 압축돼 있다. 너무 작으면 의존성이 빠진 것이다.
+          $size = (Get-Item $exe).Length
+          Write-Host "크기: $([math]::Round($size/1MB,1)) MB"
+          if ($size -lt 15MB) {
+            Write-Error "::error::exe 가 너무 작습니다 ($size 바이트). 의존성이 빠졌을 수 있습니다."
+            exit 1
+          }
+
+          # 개인 테마가 섞이지 않았는지. CI 는 git 에서 체크아웃하므로
+          # 추적되지 않는 파일이 낄 자리가 없지만, 누가 windows/frames 에
+          # 개인 테마를 커밋하면 그건 걸러야 한다.
+          $leak = Get-ChildItem windows\frames -Directory |
+            Where-Object { $_.Name -notin @('cute','simple','madness','derpy') }
+          if ($leak) {
+            Write-Error "::error::기본 테마가 아닌 폴더가 있습니다: $($leak.Name -join ', ')"
+            exit 1
+          }
+          Write-Host "OK: 기본 테마 4종만"
+
+      - name: 실제로 실행되는지 (연기 시험)
+        shell: pwsh
+        # PySide6 GUI 앱이라 러너의 데스크톱 세션에서 뜬다. --onefile 은
+        # 실행할 때마다 임시 폴더로 압축을 풀어서 시작이 느리니 넉넉히 준다.
+        # 살아 있으면 import 사슬(PySide6·psutil·i18n)이 전부 성공한 것이다.
+        run: |
+          $p = Start-Process -FilePath 'windows\dist\MemoryCat.exe' -PassThru
+          Start-Sleep -Seconds 20
+          if ($p.HasExited) {
+            Write-Error "::error::20초 안에 종료됐습니다 (exit code $($p.ExitCode))"
+            exit 1
+          }
+          Stop-Process -Id $p.Id -Force
+          Write-Host "OK: 20초 생존"
+
+      - name: 체크섬
+        shell: pwsh
+        run: |
+          Copy-Item windows\dist\MemoryCat.exe .\MemoryCat.exe
+          $h = Get-FileHash .\MemoryCat.exe -Algorithm SHA256
+          "$($h.Hash.ToLower())  MemoryCat.exe" | Tee-Object -FilePath checksum.txt
+          # 이 값을 릴리스 노트에 적는다. README 가 안내하는 대조 명령:
+          #   Get-FileHash .\MemoryCat.exe -Algorithm SHA256
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: MemoryCat-Windows
+          path: |
+            MemoryCat.exe
+            checksum.txt
+
+      # 릴리스에서 실행됐을 때만 붙인다. 수동 실행은 아티팩트로만 받아 보고
+      # 확인한 뒤 사람이 올린다. 위 검증이 하나라도 실패하면 여기까지 못 온다.
+      - name: 릴리스에 첨부
+        if: github.event_name == 'release'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" MemoryCat.exe --clobber

--- a/tests/test_macos_bundle.py
+++ b/tests/test_macos_bundle.py
@@ -552,6 +552,51 @@ class ReleaseSpecTests(unittest.TestCase):
         self.assertIn(f'VERSION = "{build_app.VERSION}"', source)
 
 
+class WindowsWorkflowTests(unittest.TestCase):
+    """윈도우 워크플로가 빌드 방법을 베껴 적지 않았는지 본다.
+
+    PyInstaller 인자를 YAML 에 복사해 두면, 사람이 `build_exe.bat` 으로 굽는
+    경로와 CI 가 굽는 경로가 조용히 어긋난다. 어긋난 줄 모르는 채로 릴리스가
+    나가는 것이 이 저장소가 이미 한 번 겪은 사고다.
+    """
+
+    WORKFLOW = _REPO / ".github" / "workflows" / "build-windows.yml"
+    BAT = _REPO / "windows" / "build_exe.bat"
+
+    def setUp(self):
+        if not self.WORKFLOW.is_file():
+            self.skipTest(f"워크플로가 없습니다: {self.WORKFLOW}")
+        self.source = self.WORKFLOW.read_text(encoding="utf-8")
+
+    def _code_lines(self):
+        """주석을 걷어낸 줄들. 주석에 무슨 단어가 있는지는 상관없다."""
+        out = []
+        for line in self.source.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            out.append(line)
+        return "\n".join(out)
+
+    def test_calls_the_batch_file_instead_of_repeating_it(self):
+        code = self._code_lines()
+        self.assertIn("build_exe.bat", code)
+        # PyInstaller 빌드 인자가 여기에도 있으면 진실 원천이 둘이 된다.
+        # (pip install "pyinstaller>=..." 는 빌드 호출이 아니라 설치라 괜찮다.)
+        for arg in ("--onefile", "--noconsole", "--add-data", "--hidden-import"):
+            self.assertNotIn(arg, code, f"{arg} 가 워크플로에 베껴져 있습니다")
+
+    def test_defuses_the_pause_prompts(self):
+        # build_exe.bat 은 더블클릭용이라 pause 가 있다. CI 에서 그대로 부르면
+        # 키 입력을 기다리며 잡이 멈춘다.
+        self.assertIn("pause", self.BAT.read_text(encoding="utf-8"))
+        self.assertIn("< nul", self.source)
+
+    def test_only_attaches_to_a_real_release(self):
+        # 수동 실행이 릴리스에 파일을 붙이면 검증 전 산출물이 공개된다.
+        self.assertIn("github.event_name == 'release'", self.source)
+
+
 #: Mach-O 로드 커맨드. ``LC_BUILD_VERSION`` 이 그 바이너리가 요구하는 최소
 #: OS(minos)를 담는다. 구형 툴체인은 ``LC_VERSION_MIN_MACOSX`` 를 쓴다.
 LC_BUILD_VERSION = 0x32


### PR DESCRIPTION
## 왜

지금까지 윈도우 exe 는 사람이 자기 PC 에서 구워 릴리스에 올렸다. 두 가지가 걸린다.

1. **릴리스가 그 PC 에 묶인다.** 코드 한 줄 고쳐도 그 컴퓨터가 있어야 나간다.
2. **받는 사람이 검증할 수 없다.** README 는 "출처를 확인할 수 없는 `MemoryCat.exe` 는 실행하지 마세요" 라고 적어 두었는데, 정작 릴리스에 올린 파일이 그런 파일이 된다. 문서가 제 발등을 찍는다.

Actions 에서 구우면 커밋 → 빌드 로그 → 산출물이 공개로 이어진다. 받는 쪽은 릴리스 노트의 SHA-256 과 대조해 "이 커밋에서 나온 파일" 임을 확인할 수 있다.

개인 자료가 섞일 여지도 구조적으로 사라진다 — CI 는 git 에서 체크아웃하므로 추적되지 않는 파일이 애초에 없다. (맥 빌드는 `frames/` 에 개인 테마가 쌓여 있어서 이름을 하나씩 지정해 막아야 했다.)

## 설계

**PyInstaller 인자를 YAML 에 베끼지 않았다.** `windows/build_exe.bat` 을 그대로 부른다. 베끼면 사람이 굽는 경로와 CI 가 굽는 경로가 조용히 어긋나는데, 그게 macOS zip 에서 이미 일어난 사고다. 어긋남을 막는 테스트도 넣었다 — 워크플로에 `--onefile` 같은 빌드 인자가 나타나면 실패한다.

`< nul` 이 필요하다. `build_exe.bat` 은 더블클릭용이라 끝과 오류 지점마다 `pause` 가 있는데(6군데), CI 에서는 키 입력을 기다리며 잡이 멈춘다.

## 검증 단계

- PE 매직(`MZ`) 확인 — 빌드가 반쯤 실패하고 껍데기만 남는 경우를 거른다
- 크기 하한 — 의존성 누락 감지
- `windows/frames` 에 기본 테마 4종 외 폴더가 없는지
- **20초 연기 시험** — 살아 있으면 PySide6·psutil·i18n import 사슬이 전부 성공한 것. `--onefile` 은 실행마다 임시 폴더로 풀어서 시작이 느리므로 넉넉히 준다
- SHA-256 출력 (릴리스 노트에 넣을 값)

릴리스 첨부는 `release` 이벤트일 때만 한다. 수동 실행은 아티팩트로만 받아 확인한 뒤 사람이 올린다.

## 아직 확인 안 된 것

**이 워크플로는 한 번도 실행된 적이 없다.** `workflow_dispatch` 가 기본 브랜치의 파일만 보므로, 머지한 뒤 수동 실행해서 exe 실물을 확인해야 한다. 확인 전에는 릴리스를 발행하지 말 것 — 발행 순간 자동 첨부된다.

SmartScreen 경고는 이걸로 해결되지 않는다. 코드 서명 인증서 문제라 빌드 방식과 무관하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)