### PR TITLE
폐지된 macos-13 대신 macos-15-intel 을 쓴다

### DIFF
--- a/.github/workflows/build-intel-mac.yml
+++ b/.github/workflows/build-intel-mac.yml
@@ -2,7 +2,7 @@ name: Build Intel macOS app
 
 # 애플 실리콘 zip 은 손으로 만들어 올리지만, 인텔용은 인텔 맥이 있어야 한다.
 # psutil / jiter / Pillow 에는 universal2 휠이 없어서 한 대에서 두 아키텍처를
-# 다 만들 수 없다. macos-13 러너가 x86_64 라 여기서 굽는다.
+# 다 만들 수 없다. 그래서 x86_64 러너에서 따로 굽는다.
 #
 # 굽는 방법은 `macos/memorycat.spec`(PyInstaller) 하나뿐이다.
 # `macos/build_app.py` 로 구우면 안 된다 — 그건 로컬 설치용 조립기라서 굽는
@@ -20,8 +20,17 @@ permissions:
 
 jobs:
   build:
-    # macos-14 부터는 arm64 다. 인텔 산출물을 만들려면 13 이어야 한다.
-    runs-on: macos-13
+    # 기본 macos-* 라벨은 arm64 다(macos-14 부터). 인텔 산출물을 만들려면
+    # x64 라벨을 명시해야 한다.
+    #
+    # 예전에는 `macos-13` 이었는데 GitHub 이 그 이미지를 폐지했다. 폐지된
+    # 라벨은 잡을 실패시키지 않고 **영원히 queued 로 매달아 둔다** — 실제로
+    # 55분을 기다리다 러너 미배정인 걸 확인하고서야 알았다. 러너 목록은
+    # https://github.com/actions/runner-images 의 README 에서 확인한다.
+    #
+    # 이 라벨이 또 폐지되면 같은 증상이 난다. 잡이 오래 queued 면 실패가
+    # 아니라 라벨을 먼저 의심할 것.
+    runs-on: macos-15-intel
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 무슨 일이 있었나

인텔 워크플로(#23 에서 들어온 것)를 처음 돌려 보니 **55분 동안 `queued` 에서 움직이지 않았다.** 잡을 들여다보니 러너가 배정조차 되지 않은 상태였다.

```
잡: build / queued / 러너: (빈 값)  라벨: macos-13
```

GitHub 이 macOS 13 이미지를 폐지했기 때문이다. [runner-images README](https://github.com/actions/runner-images) 의 macOS 목록에 13 이 없고(14/15/26 만 있다), 저장소 이슈에도 "macOS 13 runner is retired" 가 있다.

**주의할 점은 폐지된 라벨이 잡을 실패시키지 않는다는 것이다.** 그냥 영원히 queued 로 매달아 둔다. 로그도 오류 메시지도 없어서, 원인을 찾기 전까지는 그냥 "오래 걸리나 보다" 로 보인다. 그 함정을 워크플로 주석에 적어 두었다.

## 무엇을

`runs-on: macos-13` → `runs-on: macos-15-intel`

x64 대체 라벨은 `macos-15-intel` 과 `macos-26-intel` 이다. 15 를 골랐다. 26 은 아직 새롭고, 우리에게 필요한 것은 x86_64 툴체인이지 최신 OS 가 아니다.

## 아직 확인 안 된 것

**이 라벨로도 실제로 도는지 확인하지 못했다.** `workflow_dispatch` 가 기본 브랜치의 파일만 보므로, 머지한 뒤 수동 실행해서 인텔 zip 실물을 봐야 한다.

확인할 것: 러너가 배정되는지, `uname -m` 이 x86_64 인지, 하한이 11.0 으로 나오는지(setup-python 이 설치하는 파이썬이 python.org `python-3.12.10-macos11.pkg` 와 바이트 동일함은 이미 확인했다), 자립성·연기 시험 통과 여부.

확인 전에는 릴리스를 발행하지 말 것 — 발행 순간 자동 첨부된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)