### PR TITLE
OS 하한을 아키텍처별로 정한다

### DIFF
--- a/macos/memorycat.spec
+++ b/macos/memorycat.spec
@@ -46,6 +46,7 @@ Intel 용이 필요하면 Intel 러너에서 이 스펙을 그대로 한 번 더
 (`.github/workflows/build-intel-mac.yml`).
 """
 
+import platform
 import sys
 from pathlib import Path
 
@@ -54,6 +55,30 @@ REPO = Path(SPECPATH).resolve().parent  # noqa: F821  (SPECPATH is injected)
 
 # 릴리스 태그와 반드시 같이 움직여야 하는 값. 태그를 올리면 여기도 올린다.
 VERSION = "0.2.0"
+
+# 번들이 요구하는 최소 macOS. **아키텍처마다 다르다.**
+#
+#   arm64  → 11.0   Apple Silicon 자체가 macOS 11 부터라 더 내려갈 수 없다.
+#   x86_64 → 10.13  pyobjc 의 x86_64 휠이 여기를 타깃한다.
+#
+# 하나로 박아 두면 인텔 사용자 중 10.13~10.15 를 이유 없이 막는다(Launch
+# Services 가 아예 열어 주지 않는다). 반대로 낮게 적으면 그 사이 macOS 에서
+# dyld 가 조용히 죽인다. 둘 다 사용자에겐 "안 켜진다" 로만 보인다.
+#
+# 이 표는 손으로 관리한다. 대신 진실은 테스트가 지킨다 —
+# BuiltBundleFloorTests 가 번들 안 모든 Mach-O 의 minos 최댓값과 이 값이
+# **정확히 같은지** 본다. 휠이 올라가서 하한이 바뀌면 빌드가 시끄럽게
+# 실패하니, 그때 이 표를 고치면 된다. 조용히 틀리는 일은 없다.
+FLOOR_BY_ARCH = {
+    "arm64": "11.0",
+    "x86_64": "10.13",
+}
+_MACHINE = platform.machine()
+if _MACHINE not in FLOOR_BY_ARCH:
+    raise SystemExit(
+        f"모르는 아키텍처 {_MACHINE!r} 입니다. FLOOR_BY_ARCH 에 추가하세요."
+    )
+MINIMUM_MACOS = FLOOR_BY_ARCH[_MACHINE]
 
 # 기본 테마 목록은 apppaths 가 단일 진실 원천이다. 여기에 베껴 적으면 한쪽만
 # 고쳤을 때 조용히 어긋난다(기본 테마를 추가했는데 번들에 안 들어가는 식).
@@ -161,10 +186,12 @@ app = BUNDLE(  # noqa: F821
         # 가장 낮은 값을 갖기 때문에 무슨 값을 적어도 통과한다. 하한을 올리는
         # 것은 대개 파이썬 본체와 그 표준 라이브러리 .so 들이다.
         #
+        # 값은 위 FLOOR_BY_ARCH 가 정한다(아키텍처마다 다르다).
         # 확인은 tests/test_macos_bundle.py 의 BuiltBundleFloorTests 가 한다.
         # 빌드 후 반드시 돌린다:
-        #     MEMORY_CAT_BUNDLE="dist/Memory Cat.app" python -m pytest -q
-        "LSMinimumSystemVersion": "11.0",
+        #     MEMORY_CAT_BUNDLE="dist/Memory Cat.app" \
+        #     MEMORY_CAT_REQUIRE_BUNDLE=1 python -m pytest -q
+        "LSMinimumSystemVersion": MINIMUM_MACOS,
         # 독에 아이콘을 띄우지 않는 배경 앱. 바탕화면 위 고양이가 본체다.
         "LSUIElement": True,
         "NSHighResolutionCapable": True,


### PR DESCRIPTION
## 무엇이 걸렸나

인텔 워크플로를 처음 끝까지 돌려 보니([실행 34189360725](https://github.com/hyeonheebee/memory-cat/actions/runs/34189360725)) 하한 검사에서 실패했다.

```
AssertionError: (11, 0, 0) != (10, 13, 0)
실제 하한을 요구한 파일: _AppKit..., _CoreFoundation..., _Foundation...
```

**아키텍처마다 하한이 다르다는 것을 놓쳤다.**

| | 하한 | 왜 |
|---|---|---|
| arm64 | 11.0 | Apple Silicon 자체가 macOS 11 부터라 더 내려갈 수 없다 |
| x86_64 | **10.13** | pyobjc 의 x86_64 휠이 여기를 타깃한다 |

둘 다 11.0 으로 박아 두면 **인텔 사용자 중 10.13~10.15 를 이유 없이 막는다.** Launch Services 가 아예 열어 주지 않으므로 그 사람들에겐 "안 켜지는 앱" 이다. 검사가 잡아낸 것이 정확히 그 경우다 — 낮게 적으면 조용히 죽고, 높게 적으면 멀쩡한 맥에서 안 열린다.

## 무엇을

`platform.machine()` 으로 표에서 고른다. 모르는 아키텍처면 빌드를 멈춘다(기본값으로 넘어가면 그게 다시 조용한 실패가 된다).

표는 손으로 관리하되 **진실은 테스트가 지킨다.** `BuiltBundleFloorTests` 가 번들 안 모든 Mach-O 의 minos 최댓값과 선언값이 정확히 같은지 보므로, 휠이 올라가 하한이 바뀌면 빌드가 시끄럽게 실패한다. 조용히 틀리는 경로가 없다는 것이 요점이다.

## 그 실행에서 통과한 것들

문제는 plist 의 숫자 하나였고, **인텔 번들 자체는 제대로 만들어졌다.**

- 러너가 정말 인텔인지 확인 (`uname -m` = x86_64) ✅
- 번들 굽기 ✅
- **자립성 검증 — 외부 절대경로 0건** ✅
- **8초 연기 시험** ✅ (맥 러너에서 AppKit 앱이 뜨는지가 가장 불확실했는데 통과)

## 검증

arm64 재빌드 결과 선언값 11.0 그대로, 테스트 172개 통과. x86_64 쪽은 머지 후 인텔 워크플로를 다시 돌려 확인해야 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)