### PR TITLE
이름과 그림은 라이선스에 포함되지 않는다고 밝힌다

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,12 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+The name "Memory Cat" / "메모리 뚱냥이" and the cat artwork are not covered by
+the license above. If you redistribute a modified version, please give it a
+different name.
+
+위 라이선스는 코드에 대한 것입니다. "Memory Cat" / "메모리 뚱냥이" 라는 이름과
+고양이 그림은 포함되지 않습니다. 수정본을 배포하실 때는 다른 이름을 써 주세요.

--- a/README.md
+++ b/README.md
@@ -399,3 +399,12 @@ pet sprite sheets.
 ## Author and license
 
 Built by Hyeonhee Shim (@hyeonheebee). Code by Codex; planning, review, and demo by Claude. MIT License.
+
+The MIT License covers the code. The name **"Memory Cat" / "메모리 뚱냥이"** and
+the cat artwork are not part of that grant — if you redistribute a modified
+version, please give it a different name.
+
+The Windows build bundles **PySide6**, which is licensed under the LGPL. Its
+source and build script are in [`windows/`](windows/), and the release
+executable is built from them by [GitHub Actions](.github/workflows/build-windows.yml),
+so you can rebuild it yourself with a modified PySide6 if you wish.


### PR DESCRIPTION
## 왜

MIT 는 "the Software" 곧 **코드**에 대한 허락이다. 프로젝트 **이름**은 상표 영역이라 자동으로 넘어가지 않는데, 저장소에 있는 것은 다 MIT 라고 읽는 사람이 많다. 헷갈리지 않게 적어 둔다.

코드는 가져다 써도 되지만 "메모리 뚱냥이" 라는 이름으로 재배포하지는 말아 달라는 뜻이다. 파이어폭스가 코드는 열되 이름은 열지 않아서 데비안이 아이스위즐로 이름을 바꿔 배포했던 것과 같은 구조다.

**한계도 분명히 해 둔다**: 한국은 상표를 등록해야 권리가 생기므로 이 문장 자체가 등록 상표권을 만들지는 않는다. 의사를 분명히 밝혀 두는 것이고, 실무적으로는 대부분 이것만으로 충분하다.

## 함께 넣은 것 — PySide6 LGPL 고지

조사 중에 확인했다. 윈도우 빌드가 담는 PySide6 는 `LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only` 다. LGPL 은 받는 사람이 그 라이브러리를 바꿔 다시 링크할 수 있어야 한다고 요구한다.

`windows/` 에 소스와 빌드 스크립트가 있고 릴리스 exe 는 그걸로 GitHub Actions 에서 굽기 때문에 실제로 다시 빌드할 수 있다 — 그 경로를 README 에 명시한다. 맥 쪽 의존성은 전부 MIT/BSD/Apache 라 별도 의무가 없다.

## 검증

테스트 169개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)