### PR TITLE
버전을 0.3.0 으로 올린다

### DIFF
--- a/macos/build_app.py
+++ b/macos/build_app.py
@@ -52,7 +52,7 @@ INTERPRETER_NAME = "MemoryCatPython"
 PYTHON_HOME_FILE = "pythonhome"
 # 릴리스 빌드(macos/memorycat.spec)와 같은 값이어야 한다. 두 경로가 서로 다른
 # 버전을 새기면 사용자가 어느 쪽으로 설치했는지 구별할 수 없다.
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 
 #: 번들 안에서의 아이콘 파일 이름. ``CFBundleIconFile`` 에 이 값이 그대로
 #: 들어간다. 확장자를 붙여 둔다 — 애플 문서가 허용하는 형태고(크롬도

--- a/macos/memorycat.spec
+++ b/macos/memorycat.spec
@@ -54,7 +54,7 @@ from pathlib import Path
 REPO = Path(SPECPATH).resolve().parent  # noqa: F821  (SPECPATH is injected)
 
 # 릴리스 태그와 반드시 같이 움직여야 하는 값. 태그를 올리면 여기도 올린다.
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 
 # 번들이 요구하는 최소 macOS. **아키텍처마다 다르다.**
 #


### PR DESCRIPTION
메모리/디스크 선택 기능(#28)이 들어갔다. 사용자에게 보이는 동작이 바뀌었으므로(기본값이 디스크에서 메모리로) 패치가 아니라 마이너를 올린다.

두 빌드 경로가 서로 다른 버전을 새기면 사용자 지원 때 어느 쪽으로 설치했는지 구별할 수 없다. `tests/test_macos_bundle.py` 의 `test_both_build_paths_stamp_the_same_version` 이 이 일치를 강제한다.

테스트 181개 통과.

머지되면 v0.3.0 을 발행한다. 발행 순간 인텔 zip 과 윈도우 exe 가 자동으로 붙는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)