### PR TITLE
고양이가 거꾸로 움직이던 것을 고친다 (+ 윈도우 정보창 회귀)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 *메모리 뚱냥이 — an OpenAI Build Week project*
 
-> Your disk usage, visualized as a cat that gets chonkier as your drive fills up.
+> Your memory pressure, visualized as a cat that gets chonkier as your Mac fills up.
 
 <p align="center">
-  <img src="./docs/chonk-loop.gif" alt="A cat getting rounder as the disk fills up" width="300">
+  <img src="./docs/chonk-loop.gif" alt="A cat getting rounder as memory fills up" width="300">
 </p>
 
 Memory Cat is a desktop pet for macOS, with a lightweight Windows version. It
 turns an invisible system metric into something you can understand at a glance:
-the fuller your drive gets, the rounder your cat becomes.
+the fuller your Mac's memory gets, the rounder your cat becomes.
 
 The killer demo feature makes that cat personal. Give Memory Cat one photo of
 your pet, and **gpt-image-2** creates a six-stage chonk progression that the app
@@ -22,7 +22,7 @@ automatically converts into a custom 40-frame desktop theme.
   <tr>
     <td align="center">
       <img src="./cute.png" width="260"><br>
-      <sub>The default cat gets rounder as disk usage rises</sub>
+      <sub>The default cat gets rounder as memory fills up</sub>
     </td>
     <td align="center">
       <img src="./simple.png" width="260"><br>
@@ -50,7 +50,7 @@ automatically converts into a custom 40-frame desktop theme.
   pet's distinctive colors, markings, face, and ears while generating a
   six-stage horizontal sprite sheet. Memory Cat segments it and builds the full
   40-frame theme automatically.
-- **The complete chonk chart:** disk usage moves your cat through **A fine boi →
+- **The complete chonk chart:** memory pressure moves your cat through **A fine boi →
   He chomnk → A heckin' chonker → HEFTYCHONK → MEGACHONKER → OH LAWD HE
   COMIN**.
 - **“🐾 What did you eat?” diagnosis:** GPT-5.6 (`gpt-5.6-luna`) explains why the
@@ -71,6 +71,30 @@ automatically converts into a custom 40-frame desktop theme.
 
 The AI-powered items above are macOS only. See
 [Install on Windows](#install-on-windows) for what the Windows build covers.
+
+## What makes him chonky
+
+By default the cat follows **memory** — close a few apps and he slims down
+within seconds. Right-click → **What makes him chonky** to switch:
+
+| Choice | He slims down when you… |
+|---|---|
+| **Memory** (default) | close apps |
+| **Storage** | delete files |
+| **Whichever is fuller** | do either |
+
+Memory is the default because that is usually what makes a Mac feel slow —
+when RAM runs out, macOS pushes pages to swap and pulls them back, and you feel
+the wait. Storage matters too: a full drive leaves swap no room to grow.
+
+> Swap usage is deliberately **not** part of the score. macOS creates and
+> removes swap files on demand, so `used / total` sits at 80–90% no matter what
+> and even moves the wrong way — when pressure rises and the kernel grows the
+> swap file, the ratio falls. Counting it made the cat slim down after a reboot
+> while the Mac was actually more pressured than before. The diagnosis still
+> reports swap; it just does not decide his size.
+
+The Windows build follows storage only.
 
 ## Privacy
 
@@ -123,7 +147,7 @@ Nothing to install — unzip and run.
 | | File | Notes |
 |---|---|---|
 | macOS (Apple Silicon) | `Memory-Cat-macOS-AppleSilicon.zip` | macOS 11 or later |
-| macOS (Intel) | `Memory-Cat-macOS-Intel.zip` | macOS 11 or later |
+| macOS (Intel) | `Memory-Cat-macOS-Intel.zip` | macOS 10.13 or later |
 | Windows | `MemoryCat.exe` | x64. No AI features — and no network requests at all |
 
 Prefer to build it yourself, or want it to start automatically at login?

--- a/brain.py
+++ b/brain.py
@@ -360,6 +360,11 @@ def _fallback_ai(
     disk_percent = float(disk.get("percent", 0))
     pressure = float(ram.get("pressure_score", ram.get("percent", 0)))
     ram_total = int(ram.get("total_bytes", 0))
+    # 압박 점수는 이제 RAM 만 본다(metrics.pressure_score 참고). 그래서 스왑을
+    # 얘기하려면 스냅샷의 실사용량을 직접 봐야 한다. 점수가 높다고 스왑 탓을
+    # 하면 스왑이 0 인 기계에서도 그렇게 말하게 된다.
+    swap_used = int(snapshot.get("swap", {}).get("used_bytes", 0))
+    swapping = swap_used >= 1024 ** 3  # 1GB 넘게 밀려나 있으면 언급할 값어치가 있다
     why: List[str] = []
 
     if lang == LANGUAGE_EN:
@@ -372,11 +377,13 @@ def _fallback_ai(
                 f"Disk usage is high at {disk_percent:.0f}%, which can constrain temporary files and swap space."
             )
         if pressure >= 80:
-            why.append(
-                f"Memory pressure is {pressure:.0f}, so swapping may be adding latency."
-            )
+            why.append(f"Memory is {pressure:.0f}% full, so there is little room left.")
         elif pressure >= 65:
-            why.append(f"Memory pressure is somewhat high at {pressure:.0f}.")
+            why.append(f"Memory is fairly full at {pressure:.0f}%.")
+        if swapping:
+            why.append(
+                f"{human_gb(swap_used)} has been pushed out to swap, which adds latency when it is read back."
+            )
     else:
         if disk_percent >= 90:
             why.append(
@@ -387,11 +394,13 @@ def _fallback_ai(
                 f"디스크 사용률이 {disk_percent:.0f}%로 높아 임시 파일과 스왑 공간이 빠듯할 수 있습니다."
             )
         if pressure >= 80:
-            why.append(
-                f"메모리 압박 점수가 {pressure:.0f}점이라 스왑 사용으로 지연이 생길 수 있습니다."
-            )
+            why.append(f"메모리가 {pressure:.0f}% 차 있어 남은 자리가 얼마 없습니다.")
         elif pressure >= 65:
-            why.append(f"메모리 압박 점수가 {pressure:.0f}점으로 다소 높습니다.")
+            why.append(f"메모리가 {pressure:.0f}% 로 다소 차 있습니다.")
+        if swapping:
+            why.append(
+                f"{human_gb(swap_used)} 가 스왑으로 밀려나 있어, 다시 불러올 때 지연이 생깁니다."
+            )
 
     if apps:
         top = apps[0]

--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -839,7 +839,12 @@ class CatController(NSObject):
             tr(language, "mood_detail", mood=mood, percent=round(pct),
                source=tr(language, f"source_{source}")),
             tr(language, "disk_detail", percent=dpct, used=mc.human_gb(disk.used), total=mc.human_gb(disk.total), free=mc.human_gb(disk.free)),
-            tr(language, "ram_detail", percent=vm.percent, used=mc.human_gb(vm.used), total=mc.human_gb(vm.total)),
+            # `vm.used` 를 쓰면 안 된다. macOS 에서 그건 active+wired 라
+            # 압축 메모리를 빼는데, `vm.percent` 는 포함한다. 한 줄에 나란히
+            # 두면 "RAM 70% · 9.0/18.0 GB"(=50%) 처럼 자기모순이 된다.
+            tr(language, "ram_detail", percent=vm.percent,
+               used=mc.human_gb(vm.total - vm.available),
+               total=mc.human_gb(vm.total)),
         ]
         if sw.total > 0:
             self.detail.append(tr(language, "swap_detail", percent=sw.percent, used=mc.human_gb(sw.used), total=mc.human_gb(sw.total)))

--- a/metrics.py
+++ b/metrics.py
@@ -43,17 +43,37 @@ def disk_usage():
 
 
 def pressure_score():
-    """0~100 메모리 압박 점수. RAM 60% + 스왑 40% 가중."""
+    """0~100 메모리 압박 점수 = 쓸 수 있는 RAM 이 얼마나 없는가.
+
+    ``0`` 이면 RAM 이 통째로 비어 있고, ``100`` 이면 숨 쉴 곳이 없다.
+    ``psutil`` 의 ``vm.percent`` 가 정확히 ``(total - available) / total`` 이고
+    macOS 에서 ``available = inactive + free`` 이므로, 압축 메모리는 이미 이
+    값에 반영되어 있다.
+
+    **스왑은 점수에 넣지 않는다.** ``swap.percent`` 는 ``used/total`` 인데
+    macOS 는 스왑 파일을 수요에 맞춰 만들고 지운다. 분자와 분모가 같이
+    움직여서 늘 80~90% 에 붙어 있고, RAM 압박과의 상관이 사실상 없다. 게다가
+    **부호가 뒤집힌다** — 압박이 심해져 커널이 스왑 파일을 키우면 분모만
+    커져서 percent 가 오히려 내려간다.
+
+    실측(2026-09, 18GB 맥): 재부팅으로 스왑이 6.9GB→0.5GB 로 비워지자 옛
+    가중 점수는 80.9→67.9 로 여섯 칸이나 홀쭉해졌다. 그런데 같은 순간 실제
+    여유 RAM 은 4.1GB→3.6GB 로 **줄었다**. 사용자에게 거짓을 보여 준 것이다.
+
+    스왑 값 자체는 계속 돌려준다. 진단(:mod:`brain`)은 "왜 느린가" 를
+    설명해야 하므로 여전히 필요하다. 다만 **몸집을 정하는 데는 쓰지 않는다.**
+    """
     vm = psutil.virtual_memory()
     sw = psutil.swap_memory()
-    return 0.6 * vm.percent + 0.4 * sw.percent, vm, sw
+    return float(vm.percent), vm, sw
 
 
 def safe_pressure_score():
-    """스왑 조회가 실패해도 RAM 기준 점수를 돌려준다.
+    """스왑 조회가 실패해도 같은 점수를 돌려준다.
 
-    일부 psutil/macOS 조합은 ``swap_memory()`` 만 OSError 를 낸다. 알 수 없는
-    스왑을 사용 중이라고 추측하지 않고 0 으로 두며 RAM 측정은 유지한다.
+    일부 psutil/macOS 조합은 ``swap_memory()`` 만 OSError 를 낸다. 점수가 이미
+    RAM 만 보므로 스왑을 못 읽어도 값이 달라지지 않는다 — 예전에는 이때 점수가
+    스왑 몫만큼 폭락해서, 메모리는 그대로인데 고양이가 갑자기 홀쭉해졌다.
     ``brain.collect_metrics`` 와 같은 처리를 GUI 타이머에서도 쓰기 위한 것.
     """
     try:
@@ -61,7 +81,7 @@ def safe_pressure_score():
     except OSError:
         vm = psutil.virtual_memory()
         sw = SimpleNamespace(total=0, used=0, percent=0.0)
-        return 0.6 * vm.percent, vm, sw
+        return float(vm.percent), vm, sw
 
 
 def top_memory_apps(limit=5):

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -840,7 +840,7 @@ class SizeSourceTests(unittest.TestCase):
         disk = SimpleNamespace(
             total=100, used=50, free=50, percent=50.0
         )
-        vm = SimpleNamespace(total=8, used=4, percent=50.0)
+        vm = SimpleNamespace(total=8, used=4, available=4, percent=50.0)
         sw = SimpleNamespace(total=0, used=0, percent=0.0)
 
         with (
@@ -879,7 +879,7 @@ class SizeSourceTests(unittest.TestCase):
                 controller.view = Mock()
                 controller._maybe_prompt_disk_full = Mock()
                 disk = SimpleNamespace(total=100, used=50, free=50, percent=50.0)
-                vm = SimpleNamespace(total=8, used=4, percent=50.0)
+                vm = SimpleNamespace(total=8, used=4, available=4, percent=50.0)
                 sw = SimpleNamespace(total=0, used=0, percent=0.0)
                 with (
                     patch.object(desktop_cat.mc, "disk_usage", return_value=disk),

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,6 +1,100 @@
+import ast
+import pathlib
+import string
 import unittest
 
 import i18n
+
+_REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+class FormatArgumentTests(unittest.TestCase):
+    """``tr()`` 을 부르는 모든 곳이 그 문구가 요구하는 인자를 다 넘기는지 본다.
+
+    v0.3.0 에서 공용 문구 ``mood_detail`` 에 ``{source}`` 를 더했는데 맥판만
+    고치고 윈도우판(`windows/windows_cat.pyw`)을 놓쳤다. 윈도우의 갱신 루프는
+    한 틱이 실패해도 삼키도록 되어 있어서, 앱은 멀쩡히 도는데 우클릭 정보창만
+    통째로 비었다. 에러도 안 뜨고 기존 검사도 못 잡았다 — 그 검사는 "키가 두
+    언어에 다 있는가" 만 봤기 때문이다.
+
+    문구를 mac/win 이 함께 쓰므로 한쪽만 고치는 실수가 다시 나기 쉽다.
+    """
+
+    #: 검사할 소스. 윈도우판은 PySide6 가 없어 import 할 수 없으므로 글로 읽는다.
+    SOURCES = (
+        "desktop_cat.py",
+        "windows/windows_cat.pyw",
+        "brain.py",
+        "personality.py",
+        "vision_theme.py",
+        "import_theme.py",
+    )
+
+    @staticmethod
+    def _placeholders(template):
+        """``"{a} {b:.0f}"`` → ``{"a", "b"}``. 형식 지정자는 떼어낸다."""
+        return {
+            name.split(".")[0].split("[")[0]
+            for _, name, _, _ in string.Formatter().parse(template)
+            if name
+        }
+
+    def _tr_calls(self, path):
+        """``tr(language, "키", ...)`` 중 키가 상수인 것만. 동적 키는 못 본다."""
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "tr"):
+                continue
+            if len(node.args) < 2 or not isinstance(node.args[1], ast.Constant):
+                continue
+            if isinstance(node.args[1].value, str):
+                yield node
+
+    def test_every_call_passes_the_arguments_its_string_needs(self):
+        missing = []
+        checked = 0
+        for name in self.SOURCES:
+            path = _REPO / name
+            if not path.is_file():
+                continue
+            for node in self._tr_calls(path):
+                key = node.args[1].value
+                given = {kw.arg for kw in node.keywords if kw.arg}
+                for language in ("ko", "en"):
+                    template = i18n._STRINGS[language].get(key)
+                    if template is None:
+                        continue
+                    checked += 1
+                    lack = self._placeholders(template) - given
+                    if lack:
+                        missing.append(
+                            f"{name}:{node.lineno} tr(..., {key!r}) 에 "
+                            f"{sorted(lack)} 가 빠졌습니다 [{language}]"
+                        )
+        self.assertGreater(checked, 0, "tr() 호출을 하나도 못 찾았습니다")
+        self.assertEqual(missing, [], "\n" + "\n".join(missing))
+
+    def test_every_literal_key_exists(self):
+        """없는 키를 부르면 그 자리에서 KeyError 가 난다."""
+        unknown = []
+        for name in self.SOURCES:
+            path = _REPO / name
+            if not path.is_file():
+                continue
+            for node in self._tr_calls(path):
+                key = node.args[1].value
+                if key not in i18n._STRINGS["ko"]:
+                    unknown.append(f"{name}:{node.lineno} {key!r}")
+        self.assertEqual(unknown, [], "\n" + "\n".join(unknown))
+
+    def test_both_languages_carry_the_same_keys(self):
+        """한쪽에만 있는 키는 그 언어에서 그 문구를 깨뜨린다."""
+        ko = set(i18n._STRINGS["ko"])
+        en = set(i18n._STRINGS["en"])
+        self.assertEqual(ko - en, set(), f"영어에 없는 키: {sorted(ko - en)}")
+        self.assertEqual(en - ko, set(), f"한국어에 없는 키: {sorted(en - ko)}")
 
 
 class I18nTests(unittest.TestCase):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -85,7 +85,9 @@ class MetricsTests(unittest.TestCase):
         ):
             score, measured_vm, swap = metrics.safe_pressure_score()
 
-        self.assertAlmostEqual(score, 30.0)
+        # 스왑을 못 읽어도 점수가 흔들리면 안 된다. 예전에는 이 경우 점수가
+        # 스왑 몫만큼 폭락해서, 메모리는 그대로인데 고양이가 갑자기 홀쭉해졌다.
+        self.assertAlmostEqual(score, 50.0)
         self.assertIs(measured_vm, vm)
         self.assertEqual((swap.total, swap.used, swap.percent), (0, 0, 0.0))
 
@@ -98,8 +100,69 @@ class MetricsTests(unittest.TestCase):
         ):
             score, measured_vm, swap = metrics.safe_pressure_score()
 
-        self.assertAlmostEqual(score, 40.0)
+        self.assertAlmostEqual(score, 50.0)
         self.assertIs(swap, sw)
+
+
+class PressureScoreTests(unittest.TestCase):
+    """압박 점수는 **쓸 수 있는 RAM 이 얼마나 없는가** 만 본다.
+
+    예전에는 ``0.6*RAM + 0.4*스왑`` 이었다. 그런데 macOS 의
+    ``swap.percent`` 는 ``used/total`` 인데 커널이 스왑 파일을 수요에 맞춰
+    만들고 지우기 때문에 분자와 분모가 같이 움직인다. 늘 80~90% 에 붙어
+    있어서 정보가 없고, 게다가 **부호가 뒤집힌다** — 압박이 심해져 스왑
+    파일이 커지면 분모만 커져서 percent 가 오히려 내려간다.
+
+    실측(2026-09): 재부팅으로 스왑이 6.9GB→0.5GB 로 비워지자 옛 점수는
+    80.9→67.9 로 여섯 칸이나 홀쭉해졌다. 같은 순간 실제 여유 RAM 은
+    4.1GB→3.6GB 로 **줄었다**. 고양이가 거짓말을 한 것이다.
+    """
+
+    def test_score_is_exactly_the_ram_percentage(self):
+        vm = SimpleNamespace(total=8, used=4, percent=63.8)
+        sw = SimpleNamespace(total=2, used=1, percent=48.9)
+        with (
+            patch.object(metrics.psutil, "virtual_memory", return_value=vm),
+            patch.object(metrics.psutil, "swap_memory", return_value=sw),
+        ):
+            score, measured_vm, swap = metrics.pressure_score()
+        self.assertAlmostEqual(score, 63.8)
+        self.assertIs(measured_vm, vm)
+        self.assertIs(swap, sw)
+
+    def test_swap_does_not_move_the_score(self):
+        """스왑만 달라지면 점수는 그대로여야 한다."""
+        vm = SimpleNamespace(total=8, used=4, percent=70.0)
+        scores = []
+        for swap_percent in (0.0, 50.0, 100.0):
+            sw = SimpleNamespace(total=2, used=1, percent=swap_percent)
+            with (
+                patch.object(metrics.psutil, "virtual_memory", return_value=vm),
+                patch.object(metrics.psutil, "swap_memory", return_value=sw),
+            ):
+                scores.append(metrics.pressure_score()[0])
+        self.assertEqual(scores, [70.0, 70.0, 70.0])
+
+    def test_swap_is_still_reported_for_diagnosis(self):
+        """점수에서 뺐다고 스왑을 안 보는 건 아니다. 진단은 계속 쓴다."""
+        vm = SimpleNamespace(total=8, used=4, percent=70.0)
+        sw = SimpleNamespace(total=2, used=1, percent=99.0)
+        with (
+            patch.object(metrics.psutil, "virtual_memory", return_value=vm),
+            patch.object(metrics.psutil, "swap_memory", return_value=sw),
+        ):
+            _, _, swap = metrics.pressure_score()
+        self.assertEqual(swap.percent, 99.0)
+
+    def test_closing_a_big_app_moves_the_cat_visibly(self):
+        """실측 재현: 크롬(4GB)을 닫으면 vm.percent 가 80.0 → 63.8 로 떨어졌다.
+
+        40 프레임 테마에서 여섯 칸 넘게 움직여야 사람 눈에 보인다. 이 검사가
+        깨지면 "앱을 닫으면 홀쭉해진다" 는 약속이 깨진 것이다.
+        """
+        frames = 40
+        moved = (80.0 - 63.8) / 100 * (frames - 1)
+        self.assertGreater(moved, 5.0, f"{moved:.1f}칸밖에 안 움직인다")
 
 
 if __name__ == "__main__":

--- a/windows/windows_cat.pyw
+++ b/windows/windows_cat.pyw
@@ -221,7 +221,13 @@ class Cat(QtWidgets.QWidget):
 
         mood = chonk_stage(dpct, language)
         self.detail = [
-            tr(language, "mood_detail", mood=mood, percent=round(dpct)),
+            # `source` 를 반드시 넘긴다. 이 문구는 맥판과 공유하는데, 맥은
+            # 메모리/디스크를 고를 수 있어서 무엇을 보고 있는지 밝혀야 한다.
+            # 윈도우판은 디스크만 본다. 이 인자를 빠뜨리면 KeyError 가 나고,
+            # 아래 refresh() 가 예외를 삼켜서 앱은 멀쩡히 도는데 이 정보창만
+            # 통째로 빈 채로 남는다(v0.3.0 에서 실제로 그랬다).
+            tr(language, "mood_detail", mood=mood, percent=round(dpct),
+               source=tr(language, "source_disk")),
             tr(language, "disk_detail", percent=dpct, used=human_gb(disk.used),
                total=human_gb(disk.total), free=human_gb(disk.free)),
             tr(language, "ram_detail", percent=vm.percent,

--- a/windows/windows_cat.pyw
+++ b/windows/windows_cat.pyw
@@ -230,8 +230,11 @@ class Cat(QtWidgets.QWidget):
                source=tr(language, "source_disk")),
             tr(language, "disk_detail", percent=dpct, used=human_gb(disk.used),
                total=human_gb(disk.total), free=human_gb(disk.free)),
+            # `vm.used` 가 아니라 total-available 을 쓴다. 둘이 다른 것을 세서
+            # 나란히 두면 percent 와 GB 가 어긋난다(맥판 주석 참고).
             tr(language, "ram_detail", percent=vm.percent,
-               used=human_gb(vm.used), total=human_gb(vm.total)),
+               used=human_gb(vm.total - vm.available),
+               total=human_gb(vm.total)),
         ]
         if sw.total > 0:
             self.detail.append(


### PR DESCRIPTION
## 시작은 한 문장이었다

> "앱을 닫아도 고양이가 안 홀쭉해지는데?"

재 보니 단순히 둔한 게 아니라 **거꾸로** 움직이고 있었다.

## 무엇이 잘못됐나

옛 점수는 `0.6*RAM + 0.4*스왑` 이었다. 그런데 macOS 의 `swap.percent` 는 `used/total` 인데 커널이 스왑 파일을 수요에 맞춰 만들고 지운다. 분자와 분모가 같이 움직여서 늘 80~90% 에 붙어 있고, RAM 압박과 상관이 사실상 없다. **게다가 부호가 뒤집힌다** — 압박이 심해져 커널이 스왑 파일을 키우면 분모만 커져서 percent 가 내려간다.

이 맥에서 잰 재부팅 전후가 증거다.

| | 재부팅 전 | 재부팅 후 |
|---|---|---|
| 스왑 사용 | 6.9 GB | 0.5 GB |
| **여유 RAM** | **4.1 GB** | **3.6 GB** (더 나빠짐) |
| 옛 점수 | 80.9 | **67.9** (여섯 칸 홀쭉) |
| `vm.percent` | 77.0 | **80.0** (정직) |

**재부팅만 하면 고양이가 날씬해졌다. 컴퓨터는 더 답답해졌는데도.**

## 무엇을

점수를 `vm.percent` 하나로 바꾼다. macOS 에서 이 값은 `(total - available) / total` 이고 `available = inactive + free` 이므로 압축 메모리가 이미 반영돼 있다.

**재스케일은 하지 않는다.** 크롬(4GB)을 닫았을 때 80.0 → 63.8 로 16.2점이 움직이고, 40프레임 테마에서 **6.3칸**이라 이미 충분히 보인다. 구간을 좁히면 작은 변동에 고양이가 튀고, 그 경계값은 맥 한 대에서 관측한 근거 없는 숫자가 된다.

스왑 값 자체는 계속 돌려준다. 진단은 "왜 느린가" 를 설명해야 하므로 필요하다. 다만 몸집을 정하는 데는 쓰지 않는다.

## 함께 고친 것

**윈도우 정보창이 통째로 사라지던 회귀** — v0.3.0 에서 공용 문구 `mood_detail` 에 `{source}` 를 더하면서 맥판만 고쳤다. 윈도우는 `KeyError` 가 나는데 `refresh()` 가 삼켜서, 앱은 멀쩡히 도는데 우클릭 정보 블록만 빈다. **이 버그는 v0.3.0 exe 에 실려 나갔다.** `tr()` 호출부를 AST 로 훑어 인자 누락을 잡는 검사를 넣었다 — 되돌려 보니 줄 번호까지 짚는다.

**`safe_pressure_score` 폴백** — 스왑 조회가 실패하면 점수가 스왑 몫만큼 폭락했다. 메모리는 그대로인데 고양이가 갑자기 홀쭉해졌다.

**진단이 늘 스왑을 탓하던 것** — 이 맥에서 옛 점수가 늘 78~85 라 사실상 항상 "스왑 사용으로 지연" 이라고 했다. 이제 스냅샷의 실사용량을 보고 1GB 넘게 밀려나 있을 때만 언급한다.

**`ram_detail` 자기모순** (맥·윈도우 둘 다) — `vm.used` 는 압축 메모리를 빼는데 `vm.percent` 는 포함한다. 나란히 두면 "RAM 70% · 9.0/18.0 GB"(=50%) 가 됐다.

**README** 가 아직 디스크 기준이던 것, 인텔 하한이 11 로 적혀 있던 것(실제 10.13)을 고치고 "무엇으로 뚱뚱해질까" 설명을 더한다. **스왑을 왜 뺐는지도 적어 뒀다 — 안 적으면 다음에 누가 다시 넣는다.**

## 검증

테스트 **188개** 통과. 새 검사가 지키는 것:

- 스왑만 달라질 때 점수가 안 움직인다
- 스왑을 못 읽어도 점수가 그대로다
- 실측(크롬 종료 16.2점)이 여섯 칸 넘게 움직인다
- `tr()` 호출부가 문구가 요구하는 인자를 다 넘긴다

세 가지로 뚫어서 검사가 실제로 잡는 것을 확인했다: 윈도우 수정 되돌리기 / 한 언어에서 키 삭제 / 정상 상태.

🤖 Generated with [Claude Code](https://claude.com/claude-code)