### PR TITLE
버전을 0.3.1 로 올린다

### DIFF
--- a/macos/build_app.py
+++ b/macos/build_app.py
@@ -52,7 +52,7 @@ INTERPRETER_NAME = "MemoryCatPython"
 PYTHON_HOME_FILE = "pythonhome"
 # 릴리스 빌드(macos/memorycat.spec)와 같은 값이어야 한다. 두 경로가 서로 다른
 # 버전을 새기면 사용자가 어느 쪽으로 설치했는지 구별할 수 없다.
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 
 #: 번들 안에서의 아이콘 파일 이름. ``CFBundleIconFile`` 에 이 값이 그대로
 #: 들어간다. 확장자를 붙여 둔다 — 애플 문서가 허용하는 형태고(크롬도

--- a/macos/memorycat.spec
+++ b/macos/memorycat.spec
@@ -54,7 +54,7 @@ from pathlib import Path
 REPO = Path(SPECPATH).resolve().parent  # noqa: F821  (SPECPATH is injected)
 
 # 릴리스 태그와 반드시 같이 움직여야 하는 값. 태그를 올리면 여기도 올린다.
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 
 # 번들이 요구하는 최소 macOS. **아키텍처마다 다르다.**
 #


### PR DESCRIPTION
v0.3.0 에 두 가지가 실려 나갔다.

- **윈도우 우클릭 정보창이 통째로 사라짐** — 공용 문구 `mood_detail` 에 인자를 안 넘겨 `KeyError` 가 나는데 `refresh()` 가 삼켰다. 앱은 멀쩡히 도는데 정보 블록만 빈다.
- **압박 점수가 거꾸로 움직임** — 스왑 항 때문에, 재부팅해서 스왑이 비워지면 실제 메모리 압박이 더 심해졌는데도 고양이가 여섯 칸 홀쭉해졌다.

둘 다 이미 배포된 파일(v0.3.0 zip·exe)에 들어 있으므로 빨리 내보낸다. 동작 추가는 없고 고침만 있으므로 패치를 올린다.

테스트 188개 통과. 머지되면 v0.3.1 을 발행한다 — 발행 순간 인텔 zip 과 윈도우 exe 가 자동으로 붙는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)