### PR TITLE
안 도는 앱을 설치해 놓고 성공했다고 말하지 않는다

### DIFF
--- a/install_mac.command
+++ b/install_mac.command
@@ -44,6 +44,10 @@ mkdir -p "$APPS_DIR" "$APP/Contents/Resources"
 python3 -m venv "$APP/Contents/Resources/venv"
 VENVPY="$APP/Contents/Resources/venv/bin/python"
 
+# 인터프리터 사본의 이름. build_app.py 가 단일 진실 원천이므로 물어본다 —
+# 여기에 베껴 적으면 한쪽만 고쳤을 때 조용히 어긋난다.
+INTERPRETER="$(python3 -c "import sys; sys.path.insert(0, '$SRC/macos'); import build_app; print(build_app.INTERPRETER_NAME)")"
+
 # 이 순서는 바꾸면 안 된다. macOS 기본 python3 의 venv 에 딸려오는 pip 21.2.4 는
 # pyobjc-core 휠을 찾지 못해 소스 빌드로 넘어가고 "Cannot locate a working
 # compiler" 로 죽는다. pip 를 먼저 올려야 휠이 잡힌다.
@@ -57,6 +61,40 @@ VENVPY="$APP/Contents/Resources/venv/bin/python"
     --app "$APP" \
     --launch-agent "$PLIST" \
     --log "$LOG"
+
+# 복사한 인터프리터를 ad-hoc 으로 다시 서명한다.
+#
+# python.org 배포본은 Apple 개발자 인증서로 정식 서명돼 있다(TeamIdentifier
+# 가 붙어 있다). 그 바이너리를 번들 안으로 복사하면 서명이 자기 자리를 벗어나
+# "invalid Info.plist (plist or signature have been modified)" 상태가 되고,
+# 커널이 SIGKILL(종료코드 137)로 죽인다. 파이썬이 시작조차 못 하므로 로그도
+# 안 남는다 — 설치는 성공했다고 하는데 고양이만 안 뜬다.
+#
+# Homebrew 파이썬은 ad-hoc 서명이라 복사해도 이 일이 없다. 그래서 오래
+# 드러나지 않았다.
+#
+# `--sign -` 는 ad-hoc 서명이라 인증서가 필요 없다. 원래 서명을 지우고 이
+# 자리에 맞는 것으로 바꾸는 것뿐이다.
+if ! codesign --force --sign - "$APP/Contents/MacOS/$INTERPRETER" 2>/dev/null; then
+    echo "⚠️  인터프리터 재서명에 실패했습니다. 계속 진행하지만 실행이 안 될 수 있습니다."
+fi
+
+# 만든 앱이 진짜로 도는지 본다. 파일이 제자리에 있는 것과 실행되는 것은 다르다.
+# 여기서 걸러야 "✅ 완료" 라고 해 놓고 아무것도 안 뜨는 일을 막는다.
+if ! "$APP/Contents/MacOS/$INTERPRETER" -c "import sys" >/dev/null 2>&1; then
+    echo ""
+    echo "❌ 번들 안 파이썬이 실행되지 않습니다. 설치를 멈춥니다."
+    echo ""
+    echo "   쓰인 파이썬: $(python3 -c 'import sys; print(sys.base_prefix)' 2>/dev/null)"
+    echo ""
+    echo "   코드 서명 때문일 수 있습니다. 다른 파이썬으로 다시 해 보세요:"
+    echo "       PATH=\"/opt/homebrew/bin:\$PATH\" ./install_mac.command"
+    echo ""
+    echo "   그래도 안 되면 이 내용을 붙여서 이슈로 남겨 주세요:"
+    echo "       codesign --verify --verbose \"$APP/Contents/MacOS/$INTERPRETER\""
+    echo ""
+    exit 1
+fi
 
 if ! plutil -lint "$APP/Contents/Info.plist" >/dev/null; then
     echo "❌ 번들 Info.plist 가 깨졌습니다. 설치를 멈춥니다."

--- a/tests/test_macos_bundle.py
+++ b/tests/test_macos_bundle.py
@@ -552,6 +552,72 @@ class ReleaseSpecTests(unittest.TestCase):
         self.assertIn(f'VERSION = "{build_app.VERSION}"', source)
 
 
+class InstallScriptTests(unittest.TestCase):
+    """`install_mac.command` 가 죽은 앱을 설치해 놓고 성공했다고 말하지 않는지.
+
+    실제로 그런 일이 있었다. python.org 파이썬을 쓰는 맥에서 설치가 "✅ 완료!"
+    를 찍었는데 고양이는 뜨지 않았다. 원인은 인터프리터 사본의 코드 서명이었다 —
+    python.org 배포본은 Apple 개발자 인증서로 정식 서명돼 있어서(TeamIdentifier
+    가 있다), 번들 안으로 복사하면 서명이 자기 Info.plist 와 안 맞게 되고 커널이
+    SIGKILL(종료코드 137)로 죽인다. Homebrew 파이썬은 ad-hoc 이라 이 일이
+    없어서 오래 드러나지 않았다.
+
+    로그도 남지 않는다. exec 단계에서 죽으므로 파이썬이 시작조차 못 한다.
+    """
+
+    SCRIPT = _REPO / "install_mac.command"
+
+    def setUp(self):
+        if not self.SCRIPT.is_file():
+            self.skipTest(f"설치 스크립트가 없습니다: {self.SCRIPT}")
+        self.source = self.SCRIPT.read_text(encoding="utf-8")
+
+    def test_the_copied_interpreter_is_re_signed(self):
+        """복사한 인터프리터는 ad-hoc 으로 다시 서명해야 실행된다."""
+        self.assertIn("codesign", self.source)
+        self.assertIn("--force", self.source)
+        # `--sign -` 가 ad-hoc 서명이다. 인증서를 요구하지 않는다.
+        self.assertRegex(self.source, r"--sign\s+-")
+
+    def test_it_checks_the_app_actually_runs(self):
+        """번들을 만든 뒤 실제로 실행해 봐야 한다.
+
+        파일이 제자리에 있는 것과 실행되는 것은 다르다. 서명이든 아키텍처든
+        의존성이든, 무엇 때문이든 안 도는 앱을 설치해 놓고 성공을 알리면 안 된다.
+        """
+        # 인터프리터 이름은 build_app 이 단일 진실 원천이다. 이름을 베껴
+        # 적었든 물어봤든, 둘 중 하나로 이 스크립트에 닿아 있어야 한다.
+        self.assertTrue(
+            build_app.INTERPRETER_NAME in self.source
+            or "INTERPRETER_NAME" in self.source,
+            "인터프리터 이름이 스크립트에 없습니다",
+        )
+        # 실제로 실행해 보는 단계가 있어야 한다. 파일 존재 확인만으로는
+        # 서명·아키텍처·의존성 문제를 못 잡는다.
+        self.assertIn('-c "import sys"', self.source)
+        # 그리고 그 검사가 성공 문구보다 앞이어야 의미가 있다.
+        # 주석에 적힌 "완료" 는 세지 않는다 — 실제로 출력하는 줄만 본다.
+        lines = self.source.splitlines()
+        def first_line(predicate):
+            for i, line in enumerate(lines):
+                if line.strip().startswith("#"):
+                    continue
+                if predicate(line):
+                    return i
+            return None
+        check = first_line(lambda ln: '-c "import sys"' in ln)
+        done = first_line(lambda ln: "echo" in ln and "완료" in ln)
+        self.assertIsNotNone(done, "성공을 출력하는 줄을 못 찾았습니다")
+        self.assertIsNotNone(check, "실행 검사를 못 찾았습니다")
+        self.assertLess(check, done, "실행 검사가 성공 문구보다 뒤에 있습니다")
+
+    def test_failure_message_names_the_cause_and_a_remedy(self):
+        """조용히 죽지 말고 무엇을 하라고 알려줘야 한다."""
+        self.assertIn("codesign", self.source)
+        for hint in ("서명", "python"):
+            self.assertIn(hint, self.source.lower() if hint == "python" else self.source)
+
+
 class WindowsWorkflowTests(unittest.TestCase):
     """윈도우 워크플로가 빌드 방법을 베껴 적지 않았는지 본다.
 


### PR DESCRIPTION
## 무슨 일이 있었나

python.org 파이썬을 쓰는 맥에서 `install_mac.command` 가 **"✅ 완료!" 를 찍었는데 고양이는 뜨지 않았다.** 로그도 비어 있어서 원인을 알 방법이 없었다.

```
codesign --verify → invalid Info.plist (plist or signature have been modified)
실행              → 종료코드 137 (SIGKILL)
```

python.org 배포본은 Apple 개발자 인증서로 정식 서명돼 있다(`TeamIdentifier=BMM5U3QVKW`). 그 바이너리를 번들 안으로 복사하면 서명이 자기 자리를 벗어나고, 커널이 exec 단계에서 죽인다. 파이썬이 시작조차 못 하므로 로그가 비어 있다.

**Homebrew 파이썬은 ad-hoc 서명이라 복사해도 이 일이 없다.** 그래서 오래 드러나지 않았다.

## 무엇을

**① 복사한 인터프리터를 ad-hoc 으로 다시 서명한다** — `codesign --force --sign -`. 인증서가 필요 없고, 원래 서명을 이 자리에 맞는 것으로 바꾸는 것뿐이다. **이걸로 python.org 파이썬도 그대로 동작한다** — 사용자에게 파이썬을 가려 쓰라고 할 필요가 없다.

**② 만든 앱이 실제로 도는지 확인한다** — 파일이 제자리에 있는 것과 실행되는 것은 다르다. 서명이든 아키텍처든 의존성이든, 무엇 때문이든 안 도는 앱을 설치해 놓고 성공을 알리면 안 된다. 실패하면 쓰인 파이썬 경로와 다시 시도할 명령을 보여 주고 종료한다.

인터프리터 이름은 `build_app.INTERPRETER_NAME` 에서 가져온다. 베껴 적으면 한쪽만 고쳤을 때 조용히 어긋난다.

## 검증

- **python.org 파이썬으로 임시 위치에 실제 설치** → 재서명 후 인터프리터 실행 확인 (`Signature=adhoc`, `TeamIdentifier=not set`, `-c print('OK')` → `OK`)
- **재서명 단계를 빼고 다시 돌림** → 검사가 실제로 막고, 원인과 다시 시도할 명령까지 출력하는 것 확인
- 테스트 **191개** 통과

## 남은 한계

재서명은 `codesign` 이 있어야 한다(Xcode Command Line Tools 에 들어 있다). 없으면 경고만 내고 계속 진행하는데, 그 경우 ②의 실행 검사가 잡는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)