### PR TITLE
검토가 잡아낸 것 둘: 헛도는 설치 검사와 brain 의 옛 공식

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -177,7 +177,10 @@ def collect_metrics(language: str = LANGUAGE_KO) -> Dict[str, Any]:
         # 유지하되 알 수 없는 스왑을 사용 중이라고 추측하지 않는다.
         vm = psutil.virtual_memory()
         swap = SimpleNamespace(total=0, used=0, percent=0.0)
-        score = 0.6 * vm.percent
+        # 점수는 RAM 만 본다. 스왑을 못 읽었다고 값이 달라질 이유가 없다 —
+        # 이 자리는 metrics.safe_pressure_score 와 반드시 같은 답을 내야 하고,
+        # test_swap_fallback_agrees_with_the_shared_metrics_fallback 이 지킨다.
+        score = float(vm.percent)
         measurement_warnings.append("swap_unavailable")
     try:
         apps = top_memory_apps()

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import brain
+import metrics
 from personality import CUSTOM_PERSONALITY
 
 
@@ -79,9 +80,46 @@ class BrainTests(unittest.TestCase):
         ):
             snapshot = brain.collect_metrics()
 
-        self.assertEqual(snapshot["ram"]["pressure_score"], 36.0)
+        # 스왑을 못 읽었다고 점수가 내려가면 안 된다. 점수는 이제 RAM 만
+        # 보므로(metrics.pressure_score 참고) vm.percent 그대로여야 한다.
+        # 예전에는 여기서 0.6 을 곱해 36.0 이 나왔다 — 같은 기계, 같은 순간에
+        # 고양이는 60 을 보고 진단은 36 을 봤다.
+        self.assertEqual(snapshot["ram"]["pressure_score"], 60.0)
         self.assertEqual(snapshot["swap"]["total_bytes"], 0)
         self.assertEqual(snapshot["measurement_warnings"], ["swap_unavailable"])
+
+    def test_swap_fallback_agrees_with_the_shared_metrics_fallback(self):
+        """brain 이 자기만의 폴백 공식을 갖지 않는다.
+
+        v0.3.1 이 metrics.pressure_score 에서 스왑을 뺐는데, brain 의 폴백
+        사본에는 옛 가중식(0.6 * vm.percent)이 그대로 남아 있었다. 두 곳이
+        같은 일을 따로 계산하면 한쪽만 고쳐도 테스트가 통과한다. 실제로 그랬다.
+
+        이 검사는 값을 베껴 적지 않는다. 두 경로에 같은 vm 을 주고 결과가
+        같은지만 본다. 그래서 나중에 공식이 또 바뀌어도 같이 따라간다.
+        """
+        disk = SimpleNamespace(total=100, used=70, free=30, percent=70.0)
+        vm = SimpleNamespace(total=200, available=80, used=120, percent=54.0)
+
+        with (
+            patch.object(brain, "disk_usage", return_value=disk),
+            patch.object(brain, "pressure_score", side_effect=OSError),
+            patch.object(brain.psutil, "virtual_memory", return_value=vm),
+            patch.object(brain, "top_memory_apps", return_value=[]),
+        ):
+            snapshot = brain.collect_metrics()
+
+        with (
+            patch.object(metrics, "pressure_score", side_effect=OSError),
+            patch.object(metrics.psutil, "virtual_memory", return_value=vm),
+        ):
+            shared, _, _ = metrics.safe_pressure_score()
+
+        self.assertEqual(
+            snapshot["ram"]["pressure_score"],
+            round(float(shared), 1),
+            "brain 의 스왑 폴백이 metrics.safe_pressure_score 와 갈라졌습니다",
+        )
 
     def test_collect_metrics_tolerates_unavailable_process_list(self):
         disk = SimpleNamespace(total=100, used=70, free=30, percent=70.0)

--- a/tests/test_macos_bundle.py
+++ b/tests/test_macos_bundle.py
@@ -579,6 +579,33 @@ class InstallScriptTests(unittest.TestCase):
         # `--sign -` 가 ad-hoc 서명이다. 인증서를 요구하지 않는다.
         self.assertRegex(self.source, r"--sign\s+-")
 
+    def _run_check_block(self):
+        """실행 검사 `if` 문의 본문. 주석은 뺀다.
+
+        스크립트 전체를 훑으면 안 된다. `codesign` 이든 `서명` 이든 다른
+        자리에도 나오는 단어라, 전체 검색으로는 실패 처리를 통째로 지워도
+        통과한다. 실제로 그랬다 — 이 블록의 `exit 1` 과 안내문 11줄을 지워도
+        예전 검사는 191개 전부 통과했다.
+        """
+        lines = self.source.splitlines()
+        start = None
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if stripped.startswith("if ") and '-c "import sys"' in stripped:
+                start = i
+                break
+        self.assertIsNotNone(start, "실행 검사 if 문을 못 찾았습니다")
+        body = []
+        for line in lines[start + 1:]:
+            if line.strip() == "fi":
+                return body
+            if line.strip().startswith("#"):
+                continue
+            body.append(line)
+        self.fail("실행 검사 if 문이 fi 로 닫히지 않았습니다")
+
     def test_it_checks_the_app_actually_runs(self):
         """번들을 만든 뒤 실제로 실행해 봐야 한다.
 
@@ -611,11 +638,35 @@ class InstallScriptTests(unittest.TestCase):
         self.assertIsNotNone(check, "실행 검사를 못 찾았습니다")
         self.assertLess(check, done, "실행 검사가 성공 문구보다 뒤에 있습니다")
 
+    def test_a_dead_interpreter_stops_the_install(self):
+        """실행 검사가 실패하면 0 이 아닌 코드로 멈춰야 한다.
+
+        검사만 해 놓고 그냥 지나가면 검사가 없는 것과 같다. 안 도는 앱을
+        설치해 놓고 "✅ 완료!" 를 찍는 그 사고가 그대로 재발한다.
+        """
+        body = self._run_check_block()
+        self.assertTrue(
+            any(line.strip() == "exit 1" for line in body),
+            "실행 검사가 실패해도 설치가 멈추지 않습니다 — 블록 안에 exit 1 이 없습니다:\n"
+            + "\n".join(body),
+        )
+
     def test_failure_message_names_the_cause_and_a_remedy(self):
-        """조용히 죽지 말고 무엇을 하라고 알려줘야 한다."""
-        self.assertIn("codesign", self.source)
-        for hint in ("서명", "python"):
-            self.assertIn(hint, self.source.lower() if hint == "python" else self.source)
+        """조용히 죽지 말고 무엇을 하라고 알려줘야 한다.
+
+        `exit 1` 만 있고 안내가 없으면 사용자는 왜 멈췄는지 모른다. 이 앱은
+        독 아이콘이 없어서(LSUIElement) 화면에 아무 흔적도 안 남는다.
+        """
+        body = self._run_check_block()
+        printed = "\n".join(
+            line for line in body if line.strip().startswith("echo")
+        )
+        self.assertTrue(printed.strip(), "실패해도 아무 말도 하지 않습니다")
+        # 원인: 코드 서명 이야기가 나와야 한다.
+        self.assertIn("codesign", printed, "안내문이 원인(코드 서명)을 짚지 않습니다")
+        # 해법: 다른 파이썬으로 다시 해 보라는 길을 줘야 한다.
+        self.assertIn("python", printed.lower(), "안내문이 해볼 것을 알려주지 않습니다")
+
 
 
 class WindowsWorkflowTests(unittest.TestCase):


### PR DESCRIPTION
v0.3.1 검토에서 나온 지적 두 가지를 직접 재현하고 고쳤다.

## 1. 설치 검사 두 개가 헛돌고 있었다

`install_mac.command` 의 실행 검사를 지키던 검사가 스크립트 **전체**에서 단어를 찾았다. `codesign` 도 `서명` 도 주석과 실제 명령에 따로 나오는 말이라, 실패 처리를 통째로 지워도 통과했다.

직접 뚫어 본 결과:

| 변형 | 고치기 전 | 고친 후 |
|---|---|---|
| 실행 검사의 `exit 1` 제거 (죽은 앱도 설치 진행) | 191 통과 | **1개 실패** |
| 실패 안내문 11줄 통째 삭제 (조용히 죽음) | 191 통과 | **1개 실패** |

v0.3.1 이 고친 것이 바로 "안 도는 앱을 설치해 놓고 성공했다고 말하지 않는다" 인데, 그것을 지키는 쪽이 없었다.

`_run_check_block()` 이 실행 검사 `if` 문의 본문만 잘라 낸다(주석 제외). 이제 두 검사가 그 안에서만 본다. `install_mac.command` 자체는 고치지 않았다 — 스크립트는 원래 맞았다.

## 2. `brain.py` 의 스왑 폴백에 옛 공식이 남아 있었다

v0.3.1 이 `metrics.pressure_score` 에서 스왑을 뺐는데, `brain.collect_metrics` 의 폴백 사본에는 `0.6 * vm.percent` 가 그대로 있었다. 실측 재현:

```
vm.percent 54.0  ->  metrics 54.0 (정답) / brain 32.4 (거짓)
```

고양이 몸집은 `desktop_cat.py` 가 `metrics.safe_pressure_score()` 로 직접 구하므로 **화면은 멀쩡했다.** 틀린 값이 간 곳은 진단 텍스트다. 스왑 조회가 `OSError` 를 내는 드문 경우에만 발동한다.

`tests/test_brain.py:82` 가 그 틀린 값(`36.0`)을 단언으로 못박고 있어서 테스트가 통과했다. 값을 고치고, **값을 베껴 적는 대신 두 경로에 같은 `vm` 을 주고 결과가 같은지 보는** 검사를 더했다. 공식이 또 바뀌어도 따라간다.

## 검증

- 기준선 **191 → 193 passed**, 5 skipped
- 세 변형(brain 옛 공식 복원 / `exit 1` 제거 / 안내문 삭제) 모두 새 검사가 잡는 것을 확인
- 실측: `vm.percent` 67.3 = metrics 폴백 67.3 = brain 폴백 67.3

## 안 고친 것

`test_closing_a_big_app_moves_the_cat_visibly` 는 여전히 상수 산술만 한다. 다만 `frame_index_for` 를 죽이면 다른 7개가 잡으므로 우선순위를 낮췄다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)