### PR TITLE
고양이가 뚱뚱한 쪽에 갇혀 있던 것 + README 거짓 + 맥·윈도우가 따로 세던 RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,13 @@ when RAM runs out, macOS pushes pages to swap and pulls them back, and you feel
 the wait. Storage matters too: a full drive leaves swap no room to grow.
 
 > Swap usage is deliberately **not** part of the score. macOS creates and
-> removes swap files on demand, so `used / total` sits at 80–90% no matter what
-> and even moves the wrong way — when pressure rises and the kernel grows the
-> swap file, the ratio falls. Counting it made the cat slim down after a reboot
-> while the Mac was actually more pressured than before. The diagnosis still
-> reports swap; it just does not decide his size.
+> removes swap files on demand, so `used / total` mostly measures how big the
+> kernel decided to make the file — the denominator moves with the numerator,
+> and the ratio swings without your Mac's pressure changing. It can even move
+> the wrong way: when pressure rises and the kernel grows the swap file, the
+> ratio falls. Counting it made the cat slim down after a reboot while the Mac
+> was actually more pressured than before. The diagnosis still reports swap; it
+> just does not decide his size.
 
 The Windows build follows storage only.
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ automatically converts into a custom 40-frame desktop theme.
   pet's distinctive colors, markings, face, and ears while generating a
   six-stage horizontal sprite sheet. Memory Cat segments it and builds the full
   40-frame theme automatically.
-- **The complete chonk chart:** memory pressure moves your cat through **A fine boi →
-  He chomnk → A heckin' chonker → HEFTYCHONK → MEGACHONKER → OH LAWD HE
-  COMIN**.
+- **The complete chonk chart:** **A fine boi → He chomnk → A heckin' chonker →
+  HEFTYCHONK → MEGACHONKER → OH LAWD HE COMIN**. Everyday use keeps him in the
+  middle of the chart; the last two names are for a Mac that is genuinely out of
+  room, so seeing one means something.
 - **“🐾 What did you eat?” diagnosis:** GPT-5.6 (`gpt-5.6-luna`) explains why the
   computer feels slow, recommends safe cleanup targets, estimates reclaimable
   space, and gives one concise piece of advice. The Korean menu label is

--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -163,6 +163,33 @@ def size_percent(source=None, memory=None, disk=None):
     return max(_memory(), _disk())
 
 
+#: 메모리로 몸집을 정할 때의 바닥값. 이 아래는 전부 제일 홀쭉한 프레임.
+#:
+#: 메모리 사용률은 0 근처로 내려가지 않는다 — 도는 맥은 늘 절반쯤 쓰고 있다.
+#: 실측(18GB, macOS 15.4.1): 평상시 65~66%, 30초 동안 1.0 포인트 변동.
+#: 재부팅 직후에도 77~80% 였다. 0~100 을 그대로 40프레임에 옮기면 고양이가
+#: 23번대에 붙어 살고, 홀쭉한 쪽 절반을 영영 못 쓴다.
+MEMORY_FLOOR = 40.0
+
+
+def body_percent(source, percent):
+    """몸집을 정할 0~100. 메모리일 때만 눈금을 다시 매긴다.
+
+    디스크는 진짜로 0~100 을 다 쓴다(빈 디스크가 있다). 그래서 건드리지
+    않는다. ``max`` 는 "둘 중 더 찬 쪽" 이라 두 값을 같은 자로 재야 하므로
+    역시 건드리지 않는다.
+
+    화면에 적히는 숫자는 이 값이 아니다. 정보창의 "RAM 65%" 와 기분 줄은
+    잰 그대로를 쓴다 — 몸집을 보기 좋게 만들자고 숫자를 바꾸면 두 개가
+    서로 다른 말을 하게 된다.
+    """
+    if source != SOURCE_MEMORY:
+        return percent
+    if percent <= MEMORY_FLOOR:
+        return 0.0
+    return (percent - MEMORY_FLOOR) / (100.0 - MEMORY_FLOOR) * 100.0
+
+
 def frame_index_for(theme, percent):
     """0~100 값을 그 테마의 프레임 번호로 옮긴다.
 
@@ -191,7 +218,9 @@ def alert_icon_path():
     except Exception:
         return FALLBACK_ALERT_ICON_PATH
     try:
-        index = frame_index_for(theme, size_percent(cfg.get("size_source")))
+        source = cfg.get("size_source")
+        index = frame_index_for(
+            theme, body_percent(source, size_percent(source)))
     except Exception:
         index = 0  # 측정에 실패해도 그 테마의 얼굴은 보여 준다.
     try:
@@ -821,7 +850,8 @@ class CatController(NSObject):
         self.score = pct
         self._maybe_prompt_disk_full(dpct)
         theme = self.cfg["theme"]
-        idx = frame_index_for(theme, pct)
+        # 몸집만 눈금을 다시 매긴다. 아래에 적히는 숫자들은 잰 그대로다.
+        idx = frame_index_for(theme, body_percent(source, pct))
         img = NSImage.alloc().initWithContentsOfFile_(frame_path(theme, idx))
         language = self.language
         # 큰 숫자가 몸집을 설명해야 한다. 메모리로 부풀었는데 디스크가 크게

--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -183,6 +183,10 @@ def body_percent(source, percent):
     잰 그대로를 쓴다 — 몸집을 보기 좋게 만들자고 숫자를 바꾸면 두 개가
     서로 다른 말을 하게 된다.
     """
+    # `size_percent` 와 같은 자를 써야 한다. 저쪽은 모르는 값을 기본값으로
+    # 바꿔서 계산하므로, 여기서 날값으로 비교하면 둘이 갈라진다.
+    if source not in SIZE_SOURCES:
+        source = DEFAULT["size_source"]
     if source != SOURCE_MEMORY:
         return percent
     if percent <= MEMORY_FLOOR:

--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -194,6 +194,31 @@ def body_percent(source, percent):
     return (percent - MEMORY_FLOOR) / (100.0 - MEMORY_FLOOR) * 100.0
 
 
+def body_size_percent(source=None, memory=None, disk=None):
+    """몸집을 정할 0~100. **눈금을 맞춘 뒤에** 지표를 고른다.
+
+    :func:`size_percent` 와 순서가 다르다. 저쪽은 잰 값끼리 비교해서 "더 찬
+    쪽" 을 고르고, 이쪽은 각자 몸집 눈금으로 옮긴 다음 "더 뚱뚱한 쪽" 을
+    고른다. 순서를 섞으면 ``max`` 가 깨진다 — 메모리만 눈금을 다시 매긴
+    채로 잰 값끼리 비교하면, 고른 결과가 두 선택지 **어느 쪽보다도** 뚱뚱해
+    진다. 실측: 메모리 71.5% / 디스크 50% 에서 memory=20, disk=20 인데
+    max=28 이 나왔다. 메뉴에서 바꾸기만 했는데 고양이가 8프레임 부푼다.
+
+    화면에 적히는 숫자는 이 값이 아니다. 그건 :func:`size_percent` 가 내는
+    잰 값을 쓴다.
+    """
+    if source not in SIZE_SOURCES:
+        source = DEFAULT["size_source"]
+    mem = body_percent(
+        SOURCE_MEMORY, size_percent(SOURCE_MEMORY, memory=memory, disk=disk))
+    dsk = size_percent(SOURCE_DISK, memory=memory, disk=disk)
+    if source == SOURCE_MEMORY:
+        return mem
+    if source == SOURCE_DISK:
+        return dsk
+    return max(mem, dsk)
+
+
 def frame_index_for(theme, percent):
     """0~100 값을 그 테마의 프레임 번호로 옮긴다.
 
@@ -222,9 +247,8 @@ def alert_icon_path():
     except Exception:
         return FALLBACK_ALERT_ICON_PATH
     try:
-        source = cfg.get("size_source")
         index = frame_index_for(
-            theme, body_percent(source, size_percent(source)))
+            theme, body_size_percent(cfg.get("size_source")))
     except Exception:
         index = 0  # 측정에 실패해도 그 테마의 얼굴은 보여 준다.
     try:
@@ -855,12 +879,19 @@ class CatController(NSObject):
         self._maybe_prompt_disk_full(dpct)
         theme = self.cfg["theme"]
         # 몸집만 눈금을 다시 매긴다. 아래에 적히는 숫자들은 잰 그대로다.
-        idx = frame_index_for(theme, body_percent(source, pct))
+        body = body_size_percent(source, memory=score, disk=dpct)
+        idx = frame_index_for(theme, body)
         img = NSImage.alloc().initWithContentsOfFile_(frame_path(theme, idx))
         language = self.language
         # 큰 숫자가 몸집을 설명해야 한다. 메모리로 부풀었는데 디스크가 크게
         # 적혀 있으면 왜 뚱뚱한지 읽을 수 없다.
-        if source == SOURCE_DISK or (source == SOURCE_MAX and dpct >= score):
+        #
+        # 비교는 **몸집을 고른 것과 같은 자로** 해야 한다. 몸집은 눈금을
+        # 맞춘 뒤에 고르는데(body_size_percent) 여기서 잰 값끼리 비교하면,
+        # 디스크가 정한 몸집인데 첫 줄에는 메모리가 적히는 일이 생긴다.
+        if source == SOURCE_DISK or (
+                source == SOURCE_MAX
+                and dpct >= body_percent(SOURCE_MEMORY, score)):
             first = f"{tr(language, 'disk')} {dpct:.0f}%"
             second = f"{tr(language, 'ram')} {vm.percent:.0f}%"
         else:

--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -839,11 +839,10 @@ class CatController(NSObject):
             tr(language, "mood_detail", mood=mood, percent=round(pct),
                source=tr(language, f"source_{source}")),
             tr(language, "disk_detail", percent=dpct, used=mc.human_gb(disk.used), total=mc.human_gb(disk.total), free=mc.human_gb(disk.free)),
-            # `vm.used` 를 쓰면 안 된다. macOS 에서 그건 active+wired 라
-            # 압축 메모리를 빼는데, `vm.percent` 는 포함한다. 한 줄에 나란히
-            # 두면 "RAM 70% · 9.0/18.0 GB"(=50%) 처럼 자기모순이 된다.
+            # 계산은 metrics.ram_used_for_display 가 한 곳에서 한다 —
+            # 맥과 윈도우가 각자 세면 갈라진다.
             tr(language, "ram_detail", percent=vm.percent,
-               used=mc.human_gb(vm.total - vm.available),
+               used=mc.human_gb(mc.ram_used_for_display(vm)),
                total=mc.human_gb(vm.total)),
         ]
         if sw.total > 0:

--- a/metrics.py
+++ b/metrics.py
@@ -68,6 +68,20 @@ def pressure_score():
     return float(vm.percent), vm, sw
 
 
+def ram_used_for_display(vm):
+    """정보창에 적을 "쓰는 중" 바이트. ``vm.percent`` 와 같은 것을 센다.
+
+    ``vm.used`` 를 쓰면 안 된다. macOS 에서 그건 active+wired 라 압축 메모리를
+    빼는데 ``vm.percent`` 는 포함한다. 한 줄에 나란히 두면 "RAM 70% ·
+    9.0/18.0 GB"(=50%) 처럼 자기모순이 된다.
+
+    맥판과 윈도우판이 각자 계산하던 것을 여기로 모았다. 이 저장소는 두 판이
+    갈라져서 이미 사고를 냈다 — v0.3.0 에서 공용 문구를 맥만 고치는 바람에
+    윈도우 정보창이 통째로 비었다.
+    """
+    return vm.total - vm.available
+
+
 def safe_pressure_score():
     """스왑 조회가 실패해도 같은 점수를 돌려준다.
 

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -474,6 +474,25 @@ class BodyPercentTests(unittest.TestCase):
                     desktop_cat.body_percent(desktop_cat.SOURCE_MAX, percent),
                     percent)
 
+    def test_an_unknown_source_falls_back_the_same_way_size_percent_does(self):
+        """`size_percent` 와 같은 자를 써야 한다.
+
+        `size_percent` 는 모르는 `source` 를 기본값(메모리)으로 바꿔서 값을
+        낸다. `body_percent` 가 날값으로 비교하면 둘이 갈라진다 — 몸집을
+        정하는 값은 메모리인데 눈금은 안 바뀌는 상태가 된다.
+
+        `alert_icon_path` 는 `cfg.get("size_source")` 를 기본값 없이 넘긴다.
+        화면 위 고양이와 알럿 아이콘이 다른 몸집이 되는 길이고, 그건 이
+        수정이 없애려던 바로 그 증상이다.
+        """
+        expected = desktop_cat.body_percent(
+            desktop_cat.DEFAULT["size_source"], 65.5)
+        for source in (None, "cpu", "", "MEMORY"):
+            with self.subTest(source=source):
+                self.assertEqual(
+                    desktop_cat.body_percent(source, 65.5), expected,
+                    f"source={source!r} 가 size_percent 와 다른 자를 쓴다")
+
     def test_an_idle_mac_is_not_stuck_in_the_fat_half(self):
         """평상시 메모리에서 고양이가 홀쭉한 쪽에 있어야 한다.
 

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -394,6 +394,49 @@ class RefreshPicksTheFrameTests(unittest.TestCase):
             index, (frames - 1) / 2,
             f"메모리 65.5% 가 {frames}프레임 중 {index}번 — 뚱뚱한 쪽이다")
 
+    def test_the_first_line_names_whichever_decided_his_body(self):
+        """`max` 에서 큰 숫자가 몸집을 설명해야 한다.
+
+        코드 주석이 그렇게 못박고 있다 — "메모리로 부풀었는데 디스크가 크게
+        적혀 있으면 왜 뚱뚱한지 읽을 수 없다". 몸집은 눈금을 맞춘 뒤에
+        고르는데 첫 줄은 잰 값끼리 비교하면 둘이 갈라진다.
+
+        실측: 메모리 65.5% / 디스크 50% 면 몸집은 디스크가 정하는데
+        (42.5 < 50) 첫 줄에는 메모리가 나왔다.
+        """
+        for memory, disk, expected in ((65.5, 50.0, "디스크"),
+                                       (71.5, 50.0, "램"),
+                                       (45.0, 40.0, "디스크"),
+                                       (30.0, 95.0, "디스크"),
+                                       (95.0, 20.0, "램")):
+            with self.subTest(memory=memory, disk=disk):
+                vm = SimpleNamespace(percent=memory, total=0, available=0)
+                sw = SimpleNamespace(percent=0.0, used=0, total=0)
+                image_class = Mock()
+                image_class.alloc.return_value.initWithContentsOfFile_.return_value = Mock()
+                view = Mock()
+                controller = SimpleNamespace(
+                    cfg={"theme": "cute", "size_source": desktop_cat.SOURCE_MAX,
+                         "size": "보통"},
+                    language="ko", detail=[], score=0.0, view=view,
+                    _maybe_prompt_disk_full=lambda percent: None,
+                )
+                with (
+                    patch.object(desktop_cat, "NSImage", image_class),
+                    patch.object(desktop_cat.mc, "disk_usage",
+                                 return_value=SimpleNamespace(
+                                     percent=disk, used=0, total=0, free=0)),
+                    patch.object(desktop_cat.mc, "safe_pressure_score",
+                                 return_value=(memory, vm, sw)),
+                    patch.object(desktop_cat.mc, "top_memory_apps",
+                                 return_value=[]),
+                ):
+                    desktop_cat.CatController._refresh_once(controller)
+                first = view.updateImage_l1_l2_.call_args[0][1]
+                self.assertIn(
+                    expected, first,
+                    f"메모리 {memory}% 디스크 {disk}% 인데 첫 줄이 {first!r}")
+
     def test_disk_is_left_on_the_raw_scale(self):
         """디스크 50% 는 한가운데여야 한다. 눈금을 건드리면 안 된다."""
         chosen = self._run_refresh(desktop_cat.SOURCE_DISK, 90.0, 50.0)
@@ -432,6 +475,47 @@ class RefreshPicksTheFrameTests(unittest.TestCase):
         self.assertIn("66", shown, f"잰 값 65.5% 가 안 보인다: {shown}")
         # 다시 매긴 값(42.5%)이 화면에 새어 나오면 안 된다.
         self.assertNotIn("42", shown, f"눈금을 다시 매긴 값이 새어 나왔다: {shown}")
+
+
+class MaxSourceBodyTests(unittest.TestCase):
+    """`max` 는 "둘 중 배부른 쪽" 이다. 둘 다보다 뚱뚱하면 안 된다.
+
+    메뉴 문구가 "메모리·디스크 중 배부른 쪽" 이고 README 표도 그렇게
+    적혀 있다. 그런데 메모리만 눈금을 다시 매기고 `max` 는 잰 값끼리
+    비교하면, 고른 결과가 두 선택지 어느 쪽보다도 뚱뚱해진다.
+
+    실측 재현(40프레임): 메모리 71.5% / 디스크 50% 에서
+    memory=20, disk=20 인데 max=28 이 나왔다. 메뉴에서 max 로 바꾸면
+    아무것도 안 변했는데 고양이가 8프레임 부풀었다.
+    """
+
+    CASES = ((65.5, 50.0), (71.5, 50.0), (80.0, 45.0), (90.0, 30.0),
+             (30.0, 95.0), (92.0, 20.0), (20.0, 20.0), (99.0, 99.0))
+
+    def _frame(self, source, memory, disk):
+        return desktop_cat.frame_index_for(
+            "cute",
+            desktop_cat.body_size_percent(source, memory=memory, disk=disk))
+
+    def test_max_is_the_fatter_of_the_two_choices(self):
+        for memory, disk in self.CASES:
+            with self.subTest(memory=memory, disk=disk):
+                mem = self._frame(desktop_cat.SOURCE_MEMORY, memory, disk)
+                dsk = self._frame(desktop_cat.SOURCE_DISK, memory, disk)
+                mx = self._frame(desktop_cat.SOURCE_MAX, memory, disk)
+                self.assertEqual(
+                    mx, max(mem, dsk),
+                    f"memory={mem} disk={dsk} 인데 max={mx} — "
+                    "둘 중 하나여야 한다")
+
+    def test_switching_to_max_never_makes_him_fatter_than_both(self):
+        """설정만 바꿨는데 고양이가 부풀면 안 된다."""
+        for memory, disk in self.CASES:
+            with self.subTest(memory=memory, disk=disk):
+                mx = self._frame(desktop_cat.SOURCE_MAX, memory, disk)
+                both = max(self._frame(desktop_cat.SOURCE_MEMORY, memory, disk),
+                           self._frame(desktop_cat.SOURCE_DISK, memory, disk))
+                self.assertLessEqual(mx, both)
 
 
 class BodyPercentTests(unittest.TestCase):

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pathlib
 import tempfile
 import unittest
 from pathlib import Path
@@ -343,6 +344,166 @@ class DesktopCatTests(unittest.TestCase):
             path.write_text('{"theme": "cute"}', encoding="utf-8")
             loaded = desktop_cat.load_config(path)
         self.assertEqual(loaded["size_source"], desktop_cat.SOURCE_MEMORY)
+
+
+class RefreshPicksTheFrameTests(unittest.TestCase):
+    """화면 갱신이 실제로 눈금을 다시 매긴 프레임을 고르는지.
+
+    `_refresh_once` 안에서 나는 예외는 `refresh_` 가 삼킨다(의도된 설계다 —
+    한 틱 실패했다고 고양이가 사라지면 안 된다). 그래서 이 안이 깨져도
+    프로세스는 멀쩡히 살아 있고 고양이만 얼어붙는다. 독 아이콘도 없어서
+    화면에 아무 표시가 없다. 기존 검사는 `_refresh_once` 를 통째로 Mock 으로
+    바꿔 놓아서 이 본문을 한 번도 안 돌렸다.
+    """
+
+    def _run_refresh(self, source, memory_percent, disk_percent):
+        """진짜 `_refresh_once` 를 돌리고, 고른 프레임 경로를 돌려준다."""
+        vm = SimpleNamespace(percent=memory_percent, total=0, available=0)
+        sw = SimpleNamespace(percent=0.0, used=0, total=0)
+        image_class = Mock()
+        image_class.alloc.return_value.initWithContentsOfFile_.return_value = Mock()
+
+        controller = SimpleNamespace(
+            cfg={"theme": "cute", "size_source": source, "size": "보통"},
+            language="ko",
+            detail=[],
+            score=0.0,
+            view=Mock(),
+            _maybe_prompt_disk_full=lambda percent: None,
+        )
+
+        with (
+            patch.object(desktop_cat, "NSImage", image_class),
+            patch.object(desktop_cat.mc, "disk_usage",
+                         return_value=SimpleNamespace(
+                             percent=disk_percent, used=0, total=0, free=0)),
+            patch.object(desktop_cat.mc, "safe_pressure_score",
+                         return_value=(memory_percent, vm, sw)),
+            patch.object(desktop_cat.mc, "top_memory_apps", return_value=[]),
+        ):
+            desktop_cat.CatController._refresh_once(controller)
+
+        return image_class.alloc.return_value.initWithContentsOfFile_.call_args[0][0]
+
+    def test_memory_uses_the_rescaled_frame(self):
+        """평상시 메모리 65.5% 에서 고양이가 홀쭉한 쪽에 있어야 한다."""
+        chosen = self._run_refresh(desktop_cat.SOURCE_MEMORY, 65.5, 50.0)
+        frames = desktop_cat.frame_count("cute")
+        index = int(pathlib.Path(chosen).stem.split("_")[1])
+        self.assertLess(
+            index, (frames - 1) / 2,
+            f"메모리 65.5% 가 {frames}프레임 중 {index}번 — 뚱뚱한 쪽이다")
+
+    def test_disk_is_left_on_the_raw_scale(self):
+        """디스크 50% 는 한가운데여야 한다. 눈금을 건드리면 안 된다."""
+        chosen = self._run_refresh(desktop_cat.SOURCE_DISK, 90.0, 50.0)
+        self.assertTrue(
+            chosen.endswith("cat_20.png"),
+            f"디스크 50% 가 {chosen} 를 골랐다 — 40프레임의 한가운데가 아니다")
+
+    def test_the_numbers_on_screen_stay_as_measured(self):
+        """몸집은 눈금을 바꿔도 적히는 숫자는 잰 그대로여야 한다.
+
+        "RAM 65%" 옆에 다시 매긴 눈금 값이 적히면 두 숫자가 서로 다른
+        말을 하게 된다.
+        """
+        vm = SimpleNamespace(percent=65.5, total=0, available=0)
+        sw = SimpleNamespace(percent=0.0, used=0, total=0)
+        image_class = Mock()
+        image_class.alloc.return_value.initWithContentsOfFile_.return_value = Mock()
+        controller = SimpleNamespace(
+            cfg={"theme": "cute", "size_source": desktop_cat.SOURCE_MEMORY,
+                 "size": "보통"},
+            language="ko", detail=[], score=0.0, view=Mock(),
+            _maybe_prompt_disk_full=lambda percent: None,
+        )
+        with (
+            patch.object(desktop_cat, "NSImage", image_class),
+            patch.object(desktop_cat.mc, "disk_usage",
+                         return_value=SimpleNamespace(
+                             percent=50.0, used=0, total=0, free=0)),
+            patch.object(desktop_cat.mc, "safe_pressure_score",
+                         return_value=(65.5, vm, sw)),
+            patch.object(desktop_cat.mc, "top_memory_apps", return_value=[]),
+        ):
+            desktop_cat.CatController._refresh_once(controller)
+
+        shown = " ".join(controller.detail)
+        self.assertIn("66", shown, f"잰 값 65.5% 가 안 보인다: {shown}")
+        # 다시 매긴 값(42.5%)이 화면에 새어 나오면 안 된다.
+        self.assertNotIn("42", shown, f"눈금을 다시 매긴 값이 새어 나왔다: {shown}")
+
+
+class BodyPercentTests(unittest.TestCase):
+    """메모리로 몸집을 정할 때 홀쭉한 쪽 절반을 쓸 수 있는지.
+
+    메모리 사용률은 0 근처로 내려가지 않는다. 도는 맥은 늘 절반쯤 쓰고
+    있다. 0~100 을 그대로 프레임에 옮기면 고양이가 뚱뚱한 쪽에 갇힌다.
+
+    실측(18GB, macOS 15.4.1): 평상시 65~66%. 40프레임 테마에서 25번 —
+    이미 뚱뚱한 쪽이고, 30초 동안 1.0 포인트밖에 안 움직였다.
+    """
+
+    def test_the_floor_maps_to_the_thinnest_frame(self):
+        self.assertEqual(
+            desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY,
+                                     desktop_cat.MEMORY_FLOOR),
+            0.0)
+
+    def test_full_memory_still_maps_to_the_fattest_frame(self):
+        self.assertEqual(
+            desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY, 100.0), 100.0)
+
+    def test_below_the_floor_does_not_go_negative(self):
+        self.assertEqual(
+            desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY, 5.0), 0.0)
+
+    def test_disk_is_left_alone(self):
+        """디스크는 진짜로 0~100 을 다 쓴다. 눈금을 건드리면 안 된다."""
+        for percent in (0.0, 37.0, 65.0, 100.0):
+            with self.subTest(percent=percent):
+                self.assertEqual(
+                    desktop_cat.body_percent(desktop_cat.SOURCE_DISK, percent),
+                    percent)
+
+    def test_max_compares_two_raw_percentages(self):
+        """`max` 는 "둘 중 더 찬 쪽" 이다. 한쪽만 눈금을 바꾸면 비교가 깨진다."""
+        for percent in (20.0, 65.0, 90.0):
+            with self.subTest(percent=percent):
+                self.assertEqual(
+                    desktop_cat.body_percent(desktop_cat.SOURCE_MAX, percent),
+                    percent)
+
+    def test_an_idle_mac_is_not_stuck_in_the_fat_half(self):
+        """평상시 메모리에서 고양이가 홀쭉한 쪽에 있어야 한다.
+
+        이 검사가 깨지면 "앱을 닫으면 홀쭉해진다" 를 사람이 볼 수 없다.
+        """
+        frames = desktop_cat.frame_count("cute")
+        idle = desktop_cat.frame_index_for(
+            "cute", desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY, 65.5))
+        self.assertLess(
+            idle, (frames - 1) / 2,
+            f"평상시 메모리 65.5% 가 {frames}프레임 중 {idle}번 — 뚱뚱한 쪽이다")
+
+
+class CatMovementTests(unittest.TestCase):
+    def test_closing_a_big_app_moves_the_cat_more_than_it_used_to(self):
+        """실측 재현: 크롬(4GB)을 닫으면 vm.percent 가 80.0 -> 63.8 로 떨어졌다.
+
+        예전 검사는 이 숫자들로 산술만 하고 제품 코드를 한 줄도 안 불렀다.
+        `frame_index_for` 를 `return 0` 으로 만들어도 통과했다. 이제는
+        실제로 프레임을 구한다.
+        """
+        before = desktop_cat.frame_index_for(
+            "cute", desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY, 80.0))
+        after = desktop_cat.frame_index_for(
+            "cute", desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY, 63.8))
+        moved = before - after
+        # 눈금을 다시 매기기 전에는 6칸이었다. 사람 눈에 확실히 보이려면
+        # 그보다 더 움직여야 한다.
+        self.assertGreater(
+            moved, 6, f"{moved}칸밖에 안 움직인다 — 데모에서 안 보인다")
 
 
 class SizeSourceTests(unittest.TestCase):
@@ -1494,11 +1655,28 @@ class RevealTests(unittest.TestCase):
             for index in range(11):
                 (root / "myotter" / f"cat_{index:02d}.png").write_bytes(b"png")
 
-            cases = {0.0: "cat_00.png", 50.0: "cat_05.png", 91.0: "cat_09.png",
-                     100.0: "cat_10.png"}
+            # 값을 손으로 적어 둔다. 여기서 body_percent 를 다시 부르면
+            # 제품 코드를 그대로 베낀 검사가 되어 아무것도 못 잡는다.
+            #
+            # 메모리는 눈금을 다시 매긴다(MEMORY_FLOOR=40). 도는 맥은 메모리를
+            # 0 근처까지 비우지 않으므로, 40 아래를 전부 제일 홀쭉한 프레임에
+            # 몰아 두고 40~100 을 11프레임에 편다. 디스크는 진짜로 0~100 을
+            # 다 쓰므로 그대로 둔다.
+            cases_by_source = {
+                desktop_cat.SOURCE_MEMORY: {
+                    0.0: "cat_00.png",    # 바닥 아래 -> 제일 홀쭉
+                    50.0: "cat_02.png",   # (50-40)/60 = 16.7%
+                    91.0: "cat_08.png",   # (91-40)/60 = 85.0%
+                    100.0: "cat_10.png",
+                },
+                desktop_cat.SOURCE_DISK: {
+                    0.0: "cat_00.png", 50.0: "cat_05.png",
+                    91.0: "cat_09.png", 100.0: "cat_10.png",
+                },
+            }
             # 아이콘도 설정이 고른 지표를 따라야 한다. 화면 위 고양이는 메모리로
             # 부풀어 있는데 말 거는 창에는 홀쭉한 그림이 붙으면 따로 논다.
-            for source in (desktop_cat.SOURCE_MEMORY, desktop_cat.SOURCE_DISK):
+            for source, cases in cases_by_source.items():
                 for percent, expected in cases.items():
                     with self.subTest(source=source, percent=percent):
                         vm = SimpleNamespace(percent=percent, used=0, total=0)

--- a/tests/test_macos_bundle.py
+++ b/tests/test_macos_bundle.py
@@ -618,6 +618,64 @@ class InstallScriptTests(unittest.TestCase):
             self.assertIn(hint, self.source.lower() if hint == "python" else self.source)
 
 
+class WindowsBuildScriptTests(unittest.TestCase):
+    """윈도우 exe 가 저장소 루트 모듈을 실제로 담는지.
+
+    `windows_cat.pyw` 는 `windows/` 안에 있는데 `i18n`·`metrics` 는 루트에
+    있다. PyInstaller 가 그것들을 담게 하려면 `build_exe.bat` 이
+    `--hidden-import` 로 이름을 대 줘야 한다. 안 대면 빌드는 멀쩡히 끝나고
+    exe 는 켜자마자 ImportError 로 죽는다 — 그것도 `--noconsole` 이라
+    화면에 아무것도 안 뜬 채로.
+
+    루트 모듈을 하나 더 쓰기 시작했는데 bat 을 안 고치는 것이 이 검사가
+    막으려는 일이다.
+    """
+
+    BAT = _REPO / "windows" / "build_exe.bat"
+    APP = _REPO / "windows" / "windows_cat.pyw"
+
+    def setUp(self):
+        for path in (self.BAT, self.APP):
+            if not path.is_file():
+                self.skipTest(f"파일이 없습니다: {path}")
+        self.bat = self.BAT.read_text(encoding="utf-8")
+
+    def _root_modules_imported(self):
+        """`windows_cat.pyw` 가 import 하는 것 중 저장소 루트에 있는 모듈."""
+        tree = ast.parse(self.APP.read_text(encoding="utf-8"), filename=str(self.APP))
+        names = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                names.add(node.module.split(".")[0])
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    names.add(alias.name.split(".")[0])
+        return {n for n in names if (_REPO / f"{n}.py").is_file()}
+
+    def test_every_root_module_is_declared_to_pyinstaller(self):
+        missing = sorted(
+            name for name in self._root_modules_imported()
+            if f"--hidden-import {name}" not in self.bat
+        )
+        self.assertEqual(
+            missing, [],
+            "build_exe.bat 에 --hidden-import 가 빠졌습니다: "
+            + ", ".join(missing)
+            + " — exe 가 켜자마자 조용히 죽습니다",
+        )
+
+    def test_it_stops_early_when_a_root_module_is_missing(self):
+        """저장소를 통째로 안 받은 경우를 빌드 전에 걸러야 한다."""
+        missing = sorted(
+            name for name in self._root_modules_imported()
+            if f"..\\{name}.py" not in self.bat
+        )
+        self.assertEqual(
+            missing, [],
+            "build_exe.bat 이 존재 확인을 안 하는 루트 모듈: " + ", ".join(missing),
+        )
+
+
 class WindowsWorkflowTests(unittest.TestCase):
     """윈도우 워크플로가 빌드 방법을 베껴 적지 않았는지 본다.
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -154,6 +154,7 @@ class PressureScoreTests(unittest.TestCase):
             _, _, swap = metrics.pressure_score()
         self.assertEqual(swap.percent, 99.0)
 
+
 class RamDisplayTests(unittest.TestCase):
     """정보창의 "RAM 70% · 12.6 / 18.0 GB" 가 자기모순이 되지 않는지.
 
@@ -189,18 +190,6 @@ class RamDisplayTests(unittest.TestCase):
                 )
                 shown = metrics.ram_used_for_display(vm)
                 self.assertAlmostEqual(shown / total * 100, percent, places=6)
-
-
-class CatMovementTests(unittest.TestCase):
-    def test_closing_a_big_app_moves_the_cat_visibly(self):
-        """실측 재현: 크롬(4GB)을 닫으면 vm.percent 가 80.0 → 63.8 로 떨어졌다.
-
-        40 프레임 테마에서 여섯 칸 넘게 움직여야 사람 눈에 보인다. 이 검사가
-        깨지면 "앱을 닫으면 홀쭉해진다" 는 약속이 깨진 것이다.
-        """
-        frames = 40
-        moved = (80.0 - 63.8) / 100 * (frames - 1)
-        self.assertGreater(moved, 5.0, f"{moved:.1f}칸밖에 안 움직인다")
 
 
 if __name__ == "__main__":

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -154,6 +154,44 @@ class PressureScoreTests(unittest.TestCase):
             _, _, swap = metrics.pressure_score()
         self.assertEqual(swap.percent, 99.0)
 
+class RamDisplayTests(unittest.TestCase):
+    """정보창의 "RAM 70% · 12.6 / 18.0 GB" 가 자기모순이 되지 않는지.
+
+    ``vm.used`` 는 macOS 에서 active+wired 라 압축 메모리를 빼는데,
+    ``vm.percent`` 는 포함한다. 둘을 한 줄에 나란히 두면 percent 와 GB 가
+    다른 것을 세게 되어 "RAM 70% · 9.0/18.0 GB"(=50%) 처럼 어긋난다.
+
+    맥판과 윈도우판이 이 계산을 각자 하고 있었다. 이 저장소는 맥/윈도우가
+    갈라져서 이미 두 번 사고를 냈으므로(v0.3.0 의 빈 정보창) 계산을 한 곳에
+    둔다.
+    """
+
+    def test_displayed_used_is_total_minus_available(self):
+        vm = SimpleNamespace(total=18_000_000_000, available=5_400_000_000,
+                             used=9_000_000_000, percent=70.0)
+        self.assertEqual(metrics.ram_used_for_display(vm), 12_600_000_000)
+
+    def test_displayed_used_agrees_with_the_percent_beside_it(self):
+        """GB 비율과 percent 가 같은 것을 세야 한다.
+
+        이 검사가 깨지면 사용자가 정보창에서 서로 안 맞는 두 숫자를 본다.
+        """
+        for percent in (12.5, 40.0, 63.7, 70.0, 91.0):
+            with self.subTest(percent=percent):
+                total = 18_000_000_000
+                available = int(total * (1 - percent / 100))
+                vm = SimpleNamespace(
+                    total=total,
+                    available=available,
+                    # vm.used 는 일부러 엉뚱한 값. 이걸 쓰면 검사가 깨져야 한다.
+                    used=int(total * 0.5),
+                    percent=percent,
+                )
+                shown = metrics.ram_used_for_display(vm)
+                self.assertAlmostEqual(shown / total * 100, percent, places=6)
+
+
+class CatMovementTests(unittest.TestCase):
     def test_closing_a_big_app_moves_the_cat_visibly(self):
         """실측 재현: 크롬(4GB)을 닫으면 vm.percent 가 80.0 → 63.8 로 떨어졌다.
 

--- a/windows/build_exe.bat
+++ b/windows/build_exe.bat
@@ -33,8 +33,8 @@ if not exist "frames" (
     exit /b 1
 )
 
-REM i18n.py 는 저장소 루트에 있다. windows 폴더만 복사해 온 경우 여기서
-REM 걸러 준다. 없으면 빌드는 되지만 실행할 때 죽는다.
+REM i18n.py / metrics.py 는 저장소 루트에 있다. windows 폴더만 복사해 온
+REM 경우 여기서 걸러 준다. 없으면 빌드는 되지만 실행할 때 죽는다.
 if not exist "..\i18n.py" (
     echo.
     echo [X] ..\i18n.py 를 찾을 수 없습니다.
@@ -44,11 +44,23 @@ if not exist "..\i18n.py" (
     exit /b 1
 )
 
-REM i18n.py 는 저장소 루트에 있다. --paths 로 import 경로에 넣어 준다.
+if not exist "..\metrics.py" (
+    echo.
+    echo [X] ..\metrics.py 를 찾을 수 없습니다.
+    echo     windows 폴더만 복사하지 말고 저장소를 통째로 받아 주세요.
+    popd
+    pause
+    exit /b 1
+)
+
+REM i18n.py / metrics.py 는 저장소 루트에 있다. --paths 로 import 경로에
+REM 넣고, 이름을 --hidden-import 로 대 준다. 루트 모듈을 하나 더 쓰기
+REM 시작하면 여기에도 더해야 한다 — WindowsBuildScriptTests 가 지킨다.
 pyinstaller --noconsole --onefile --name MemoryCat ^
     --add-data "frames;frames" ^
     --paths ".." ^
     --hidden-import i18n ^
+    --hidden-import metrics ^
     windows_cat.pyw
 if errorlevel 1 (
     echo.

--- a/windows/windows_cat.pyw
+++ b/windows/windows_cat.pyw
@@ -25,6 +25,9 @@ from i18n import (
     resolve_language,
     tr,
 )
+# metrics 는 저장소 루트의 플랫폼 공통 모듈이다(GUI 의존 없음). i18n 과 같은
+# 방식으로 닿는다 — build_exe.bat 의 `--paths ".."` 와 `--hidden-import`.
+from metrics import ram_used_for_display
 
 # 빌드(.exe)면 frames 는 번들 안, config 는 exe 옆에 둔다
 if getattr(sys, "frozen", False):
@@ -230,10 +233,10 @@ class Cat(QtWidgets.QWidget):
                source=tr(language, "source_disk")),
             tr(language, "disk_detail", percent=dpct, used=human_gb(disk.used),
                total=human_gb(disk.total), free=human_gb(disk.free)),
-            # `vm.used` 가 아니라 total-available 을 쓴다. 둘이 다른 것을 세서
-            # 나란히 두면 percent 와 GB 가 어긋난다(맥판 주석 참고).
+            # 계산은 metrics.ram_used_for_display 가 한 곳에서 한다 —
+            # 맥과 윈도우가 각자 세면 갈라진다.
             tr(language, "ram_detail", percent=vm.percent,
-               used=human_gb(vm.total - vm.available),
+               used=human_gb(ram_used_for_display(vm)),
                total=human_gb(vm.total)),
         ]
         if sw.total > 0:


### PR DESCRIPTION
검토에서 나온 나머지 중 "배포해서 바로 쓸 수 있게" 에 걸리는 것들. **서브에이전트 두 대가 적대적으로 검토했고, 그 지적으로 커밋 세 개를 더 붙였다.**

## 1. 고양이가 40프레임 중 23칸을 못 쓰고 있었다

메모리 사용률은 0 근처로 내려가지 않는다. 도는 맥은 늘 절반쯤 쓰고 있다. 0~100 을 그대로 프레임에 옮기니 홀쭉한 쪽 절반이 영영 안 쓰였다.

실측(18GB, macOS 15.4.1): 평상시 65~66% → 40프레임 중 25번, 30초 동안 변동 1.0 포인트.

`MEMORY_FLOOR = 40` 아래를 제일 홀쭉한 프레임에 몰고, 40~100 을 프레임 전체에 편다.

| | 전 | 후 |
|---|---|---|
| 61.6% | 프레임 24 | **14** |
| 크롬 4GB 닫기 | 6칸 | **11칸** |
| 범위 55~90% | 14칸만 씀 | **23칸** |

디스크는 안 건드린다 — 빈 디스크는 진짜로 있으므로 0~100 을 다 쓴다.

**화면에 적히는 숫자는 잰 그대로다.** 몸집만 눈금을 바꾼다. 그걸 지키는 검사도 넣었고, 일부러 오염시켜 잡히는 것까지 확인했다.

### 🔴 검토가 잡은 회귀 — `max` 가 둘 중 어느 쪽보다도 뚱뚱해졌다 (고침)

메모리만 눈금을 다시 매기는데 `max` 는 잰 값끼리 비교하고 잰 값으로 프레임을 골랐다. 순서가 섞였다.

```
메모리  디스크 | memory  disk   max
 65.5   50.0  |     17    20    26   <- 둘 다보다 뚱뚱
 71.5   50.0  |     20    20    28   <- 메뉴만 바꿔도 8프레임 부품
 90.0   30.0  |     33    12    35
```

메뉴 문구가 "메모리·디스크 중 배부른 쪽" 인데 실제로는 어느 쪽도 아닌 값이 나왔다. `body_size_percent()` 를 두고 **눈금을 맞춘 뒤에** 지표를 고르게 했다. 화면 첫 줄 비교도 같은 자로 맞췄다 — 코드 주석이 "큰 숫자가 몸집을 설명해야 한다" 고 못박고 있던 자리다.

### 🔴 검토가 잡은 것 — 헛도는 검사를 실제로는 안 지웠다 (고침)

이전 설명에 "다시 썼다" 고 적었지만, `test_desktop_cat.py` 에 새 검사를 넣었을 뿐 `test_metrics.py` 의 원본은 클래스로 감싸서 그대로 남아 있었다. `frame_index_for` 를 `return 0` 으로 만들고 나눠 돌리면 옛것은 여전히 통과했다. 게다가 눈금 바꾸기 **전** 값(6칸)을 지키고 있었다. 지웠다.

### 🟡 검토가 잡은 것 — `body_percent` 가 `source` 를 정규화 안 했다 (고침)

`size_percent` 는 모르는 값을 기본값으로 바꾸는데 이쪽은 날값으로 비교했다. `load_config` 이 항상 정규화하므로 지금은 도달 불가지만, `alert_icon_path` 가 기본값 없이 넘기고 있어 화면 위 고양이와 알럿 아이콘이 갈라지는 길이었다.

## 2. README 에 검증 가능한 거짓 둘

- `used / total` 이 "80–90% 에 고정된다" → 실측 25.7%. 논거는 맞지만 근거 숫자가 틀렸다.
- "memory pressure moves your cat through [여섯 단계]" → 마지막 둘은 90%/96% 문턱이라 거의 안 보인다. 문턱은 안 낮췄다(드물어야 뜻이 있다). 문구를 사실에 맞췄다.

## 3. 정보창의 RAM 사용량을 맥·윈도우가 따로 세고 있었다

`vm.used` 는 macOS 에서 active+wired 라 압축 메모리를 빼는데 `vm.percent` 는 포함한다. 나란히 두면 `RAM 70% · 9.0/18.0 GB`(=50%) 처럼 자기모순이 된다. 두 판 모두 고쳐져 있었지만 **각자** 갖고 있었고 검사는 0개였다. `metrics.ram_used_for_display(vm)` 로 모았다.

윈도우가 루트 모듈을 하나 더 쓰게 됐으므로 `build_exe.bat` 에 `--hidden-import metrics` 와 존재 확인을 더했다. 빠뜨리면 빌드는 끝나고 exe 가 켜자마자 ImportError 로 죽는다 — `--noconsole` 이라 화면에 아무것도 안 뜬 채로. `WindowsBuildScriptTests` 가 막는다.

## 검증

- 기준선 **191 → 208 passed**, 5 skipped
- 새 검사를 전부 뚫어서 확인. `max` 를 옛 방식으로 되돌리면 **10개**, 첫 줄 비교를 되돌리면 2개, 몸집 눈금 우회 3개, `vm.used` 되돌리기 9개, bat 선언 삭제 1개, 설치 `exit 1` 삭제 1개가 깨진다
- **윈도우 exe 를 CI 로 빌드** — 20초 연기 시험 `OK: 20초 생존`
- 발행된 **인텔 빌드를 Rosetta 로 처음 실행** — 35초 생존, 24스레드, 에러 없음

## 알고 넘어가야 할 것

**여유가 많은 맥에서는 고양이가 제일 홀쭉한 채로 멈춘다.** `MEMORY_FLOOR = 40` 은 18GB 맥 한 대에서 잰 값이라 RAM 용량에 안 맞춘다.

```
메모리 20~40%  ->  전부 프레임 0   (전에는 8~16)
```

의미상으로는 맞다(메모리가 그만큼 비어 있으면 제일 홀쭉한 게 맞다). 다만 32·64GB 맥에서 idle 이 40% 아래라면 "앱을 닫으면 홀쭉해져요" 가 그 구간에서 죽는다. **다른 용량의 맥에서 검증 못 했다.** 실사용 피드백을 보고 조정할 값이다.

## 후속 이슈 감 (이 PR 밖)

- `windows/README.txt` 의 "windows 폴더에서 `pythonw windows_cat.pyw`" 안내가 `origin/main` 에서도 이미 `ModuleNotFoundError: No module named 'i18n'` 로 깨져 있다. 이 PR 책임은 아니지만 루트 의존이 하나 늘었다.
- `install_mac.command` 의 `PLIST=` 가 하드코딩이라 설치 테스트가 사용자 LaunchAgent 를 덮어쓴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)