### PR TITLE
chore: 버전을 0.3.2 로 올린다

### DIFF
--- a/macos/build_app.py
+++ b/macos/build_app.py
@@ -52,7 +52,7 @@ INTERPRETER_NAME = "MemoryCatPython"
 PYTHON_HOME_FILE = "pythonhome"
 # 릴리스 빌드(macos/memorycat.spec)와 같은 값이어야 한다. 두 경로가 서로 다른
 # 버전을 새기면 사용자가 어느 쪽으로 설치했는지 구별할 수 없다.
-VERSION = "0.3.1"
+VERSION = "0.3.2"
 
 #: 번들 안에서의 아이콘 파일 이름. ``CFBundleIconFile`` 에 이 값이 그대로
 #: 들어간다. 확장자를 붙여 둔다 — 애플 문서가 허용하는 형태고(크롬도

--- a/macos/memorycat.spec
+++ b/macos/memorycat.spec
@@ -54,7 +54,7 @@ from pathlib import Path
 REPO = Path(SPECPATH).resolve().parent  # noqa: F821  (SPECPATH is injected)
 
 # 릴리스 태그와 반드시 같이 움직여야 하는 값. 태그를 올리면 여기도 올린다.
-VERSION = "0.3.1"
+VERSION = "0.3.2"
 
 # 번들이 요구하는 최소 macOS. **아키텍처마다 다르다.**
 #


### PR DESCRIPTION
발행 준비. `macos/build_app.py`(로컬 설치)와 `macos/memorycat.spec`(배포) 두 곳.

한쪽만 올리면 `ReleaseSpecTests::test_both_build_paths_stamp_the_same_version` 이 잡는다. spec 만 `0.3.1` 로 되돌려서 실제로 실패하는 것을 확인했다.

머지된 main 기준 **210 passed, 5 skipped.**

## v0.3.2 에 담기는 것

| | |
|---|---|
| 고양이가 40프레임 중 23칸을 못 쓰던 것 | 크롬 4GB 닫기 **6칸 → 11칸** |
| `max` 가 둘 중 어느 쪽보다도 뚱뚱해지던 것 | 검토가 잡은 회귀 |
| 스왑을 못 읽을 때 진단이 점수를 3분의 1 낮게 말하던 것 | 드문 경우 |
| README 의 검증 가능한 거짓 둘 | 스왑 "80–90% 고정", chonk 차트 과장 |
| 맥·윈도우가 따로 세던 RAM 사용량 | `metrics.ram_used_for_display` 로 통합 |
| 헛도는 검사 4개 | 전부 실제로 잡히게 고침 |

릴리스 노트 초안: `~/Downloads/memory-cat-v0.3.2-release-notes.md` (체크섬 자리표시자 6개는 발행 후 채운다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)