### PR TITLE
몸집 눈금을 이름 문턱에 맞추고 근거 없는 MEMORY_FLOOR 를 지운다

### DIFF
--- a/desktop_cat.py
+++ b/desktop_cat.py
@@ -163,35 +163,57 @@ def size_percent(source=None, memory=None, disk=None):
     return max(_memory(), _disk())
 
 
-#: 메모리로 몸집을 정할 때의 바닥값. 이 아래는 전부 제일 홀쭉한 프레임.
-#:
-#: 메모리 사용률은 0 근처로 내려가지 않는다 — 도는 맥은 늘 절반쯤 쓰고 있다.
-#: 실측(18GB, macOS 15.4.1): 평상시 65~66%, 30초 동안 1.0 포인트 변동.
-#: 재부팅 직후에도 77~80% 였다. 0~100 을 그대로 40프레임에 옮기면 고양이가
-#: 23번대에 붙어 살고, 홀쭉한 쪽 절반을 영영 못 쓴다.
-MEMORY_FLOOR = 40.0
+#: 사진으로 만든 테마의 그림 여섯 장이 각각 차지하는 프레임 구간. 40개 파일
+#: 중 서로 다른 그림은 여섯 장뿐이고 나머지는 복제본이다. 기본 테마
+#: `cute`·`simple` 도, `vision_theme` 이 반려동물 사진으로 만드는 테마도
+#: 그렇다 — `import_theme.save_theme_frames` 가 `smooth=False` 로 가장 가까운
+#: 단계를 그대로 쓴다. 섞으면 귀와 눈이 겹쳐 유령처럼 보이기 때문이다.
+_PICTURE_FRAMES = ((0, 3), (4, 11), (12, 19), (20, 27), (28, 35), (36, 39))
+
+#: 그 여섯 장을 어느 메모리 값에서 바꿀지. `i18n.chonk_stage` 의 영어 문턱과
+#: **같은 값이다.** 몸과 이름이 같은 지점에서 바뀌어야 "HEFTYCHONK" 이 뜨는
+#: 순간 몸이 그 그림이 된다.
+_MEMORY_EDGES = (0.0, 60.0, 70.0, 80.0, 90.0, 96.0, 100.0)
+
+#: 프레임 번호를 0~100 으로 되돌릴 때 쓰는 마지막 번호. 사진 테마가 40장
+#: 파일로 나오므로 39 다.
+_LAST_FRAME = 39.0
 
 
-def body_percent(source, percent):
-    """몸집을 정할 0~100. 메모리일 때만 눈금을 다시 매긴다.
+def body_percent(percent):
+    """잰 값 0~100 을 몸집 0~100 으로 옮긴다. **메모리·디스크가 같은 자를 쓴다.**
 
-    디스크는 진짜로 0~100 을 다 쓴다(빈 디스크가 있다). 그래서 건드리지
-    않는다. ``max`` 는 "둘 중 더 찬 쪽" 이라 두 값을 같은 자로 재야 하므로
-    역시 건드리지 않는다.
+    메모리 사용률은 0 근처로 내려가지 않는다 — 도는 맥은 늘 절반쯤 쓰고
+    있다. 0~100 을 그대로 옮기면 그림 여섯 장 중 두 장밖에 안 쓰인다.
+    실측(18GB, macOS 15.4.1): 관측된 값이 61~80% 였고 재부팅 직후에도 80%
+    였다.
+
+    그래서 메모리 구간을 그림 구간에 하나씩 대응시킨다. 구간 경계를 이름
+    문턱에 맞춰 두었으므로 몸과 이름이 같은 지점에서 바뀐다. 구간 **안에서는**
+    직선이라 `derpy` 처럼 진짜 40장인 테마는 계속 부드럽게 움직인다.
+
+    디스크도 같은 자를 쓴다. 앱은 이미 디스크에도 같은 문턱으로 이름을
+    붙인다(`brain.collect_metrics` 가 `chonk_stage(disk.percent)`). 자를
+    따로 쓰면 ``max`` 가 깨진다 — 메모리 71.5% 가 디스크 50% 에 지고,
+    "둘 중 더 찬 쪽" 이 사실상 디스크 전용이 된다.
 
     화면에 적히는 숫자는 이 값이 아니다. 정보창의 "RAM 65%" 와 기분 줄은
     잰 그대로를 쓴다 — 몸집을 보기 좋게 만들자고 숫자를 바꾸면 두 개가
     서로 다른 말을 하게 된다.
     """
-    # `size_percent` 와 같은 자를 써야 한다. 저쪽은 모르는 값을 기본값으로
-    # 바꿔서 계산하므로, 여기서 날값으로 비교하면 둘이 갈라진다.
-    if source not in SIZE_SOURCES:
-        source = DEFAULT["size_source"]
-    if source != SOURCE_MEMORY:
-        return percent
-    if percent <= MEMORY_FLOOR:
-        return 0.0
-    return (percent - MEMORY_FLOOR) / (100.0 - MEMORY_FLOOR) * 100.0
+    percent = min(max(float(percent), 0.0), 100.0)
+    last = len(_PICTURE_FRAMES) - 1
+    for i, (first_frame, final_frame) in enumerate(_PICTURE_FRAMES):
+        lo, hi = _MEMORY_EDGES[i], _MEMORY_EDGES[i + 1]
+        # 경계값은 **위쪽** 구간이 가져간다. 이름도 그렇게 바뀐다
+        # (`chonk_stage` 가 `percent < 60` 이면 첫 단계다). 여기서 아래쪽이
+        # 가져가면 90% 에서 이름은 MEGACHONKER 인데 몸은 그 전 그림이 된다.
+        if percent < hi or i == last:
+            span = final_frame - first_frame
+            t = 0.0 if hi == lo else (percent - lo) / (hi - lo)
+            frame = first_frame + span * min(max(t, 0.0), 1.0)
+            return frame / _LAST_FRAME * 100.0
+    return 100.0
 
 
 def body_size_percent(source=None, memory=None, disk=None):
@@ -209,9 +231,8 @@ def body_size_percent(source=None, memory=None, disk=None):
     """
     if source not in SIZE_SOURCES:
         source = DEFAULT["size_source"]
-    mem = body_percent(
-        SOURCE_MEMORY, size_percent(SOURCE_MEMORY, memory=memory, disk=disk))
-    dsk = size_percent(SOURCE_DISK, memory=memory, disk=disk)
+    mem = body_percent(size_percent(SOURCE_MEMORY, memory=memory, disk=disk))
+    dsk = body_percent(size_percent(SOURCE_DISK, memory=memory, disk=disk))
     if source == SOURCE_MEMORY:
         return mem
     if source == SOURCE_DISK:
@@ -891,7 +912,7 @@ class CatController(NSObject):
         # 디스크가 정한 몸집인데 첫 줄에는 메모리가 적히는 일이 생긴다.
         if source == SOURCE_DISK or (
                 source == SOURCE_MAX
-                and dpct >= body_percent(SOURCE_MEMORY, score)):
+                and body_percent(dpct) >= body_percent(score)):
             first = f"{tr(language, 'disk')} {dpct:.0f}%"
             second = f"{tr(language, 'ram')} {vm.percent:.0f}%"
         else:

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -401,12 +401,13 @@ class RefreshPicksTheFrameTests(unittest.TestCase):
         적혀 있으면 왜 뚱뚱한지 읽을 수 없다". 몸집은 눈금을 맞춘 뒤에
         고르는데 첫 줄은 잰 값끼리 비교하면 둘이 갈라진다.
 
-        실측: 메모리 65.5% / 디스크 50% 면 몸집은 디스크가 정하는데
-        (42.5 < 50) 첫 줄에는 메모리가 나왔다.
+        메모리와 디스크가 같은 자를 쓰고 그 자가 단조증가하므로, 결국
+        잰 값이 큰 쪽이 몸집을 정한다. 자를 한쪽만 바꾸면 이 성질이 깨진다 —
+        그때 이 검사가 잡는다.
         """
-        for memory, disk, expected in ((65.5, 50.0, "디스크"),
+        for memory, disk, expected in ((65.5, 50.0, "램"),
                                        (71.5, 50.0, "램"),
-                                       (45.0, 40.0, "디스크"),
+                                       (45.0, 40.0, "램"),
                                        (30.0, 95.0, "디스크"),
                                        (95.0, 20.0, "램")):
             with self.subTest(memory=memory, disk=disk):
@@ -437,12 +438,11 @@ class RefreshPicksTheFrameTests(unittest.TestCase):
                     expected, first,
                     f"메모리 {memory}% 디스크 {disk}% 인데 첫 줄이 {first!r}")
 
-    def test_disk_is_left_on_the_raw_scale(self):
-        """디스크 50% 는 한가운데여야 한다. 눈금을 건드리면 안 된다."""
-        chosen = self._run_refresh(desktop_cat.SOURCE_DISK, 90.0, 50.0)
-        self.assertTrue(
-            chosen.endswith("cat_20.png"),
-            f"디스크 50% 가 {chosen} 를 골랐다 — 40프레임의 한가운데가 아니다")
+    def test_disk_uses_the_same_ruler_as_memory(self):
+        """자를 따로 쓰면 `max` 가 한쪽 전용이 된다."""
+        by_disk = self._run_refresh(desktop_cat.SOURCE_DISK, 0.0, 77.0)
+        by_memory = self._run_refresh(desktop_cat.SOURCE_MEMORY, 77.0, 0.0)
+        self.assertEqual(by_disk, by_memory)
 
     def test_the_numbers_on_screen_stay_as_measured(self):
         """몸집은 눈금을 바꿔도 적히는 숫자는 잰 그대로여야 한다.
@@ -475,6 +475,73 @@ class RefreshPicksTheFrameTests(unittest.TestCase):
         self.assertIn("66", shown, f"잰 값 65.5% 가 안 보인다: {shown}")
         # 다시 매긴 값(42.5%)이 화면에 새어 나오면 안 된다.
         self.assertNotIn("42", shown, f"눈금을 다시 매긴 값이 새어 나왔다: {shown}")
+
+
+class BodyFollowsChonkStagesTests(unittest.TestCase):
+    """몸집 눈금이 이름(chonk stage)과 같은 지점에서 바뀌는지.
+
+    사진으로 만든 테마는 **그림이 6장**이다. 40개 파일 중 34개는 복제본이다.
+    기본 테마 `cute`·`simple` 도, `vision_theme` 이 반려동물 사진으로 만드는
+    커스텀 테마도 전부 그렇다(`save_theme_frames` 가 `smooth=False` 로 가장
+    가까운 단계를 그대로 쓴다 — 섞으면 귀와 눈이 겹쳐 보인다).
+
+    그림이 6장뿐이면 "몇 프레임 움직이나" 는 뜻이 없다. **어느 그림을
+    보여주나** 가 전부다. 그러니 그림이 바뀌는 지점을 앱이 이미 정해 둔
+    이름 문턱에 맞춘다. "HEFTYCHONK" 이 뜨는 순간 몸이 그 그림이 된다.
+    """
+
+    #: 6장짜리 테마에서 한 그림이 차지하는 프레임 구간.
+    BUCKETS = ((0, 3), (4, 11), (12, 19), (20, 27), (28, 35), (36, 39))
+
+    def _picture(self, percent):
+        frame = desktop_cat.frame_index_for(
+            "cute", desktop_cat.body_size_percent(
+                desktop_cat.SOURCE_MEMORY, memory=percent, disk=0.0))
+        for i, (lo, hi) in enumerate(self.BUCKETS):
+            if lo <= frame <= hi:
+                return i
+        self.fail(f"프레임 {frame} 이 어느 그림에도 안 들어갑니다")
+
+    def test_the_picture_changes_exactly_where_the_name_changes(self):
+        picture_at = [self._picture(float(p)) for p in range(101)]
+        name_at = [i18n.chonk_stage(float(p), "en") for p in range(101)]
+        picture_edges = [p for p in range(1, 101)
+                         if picture_at[p] != picture_at[p - 1]]
+        name_edges = [p for p in range(1, 101)
+                      if name_at[p] != name_at[p - 1]]
+        self.assertEqual(
+            picture_edges, name_edges,
+            f"그림은 {picture_edges} 에서 바뀌는데 이름은 {name_edges} 에서 바뀝니다")
+
+    def test_every_picture_is_reachable(self):
+        """그림 6장이 다 쓰여야 한다. 안 쓰이는 그림이 있으면 낭비다."""
+        seen = {self._picture(float(p)) for p in range(101)}
+        self.assertEqual(
+            seen, set(range(6)),
+            f"안 쓰이는 그림: {sorted(set(range(6)) - seen)}")
+
+    def test_the_body_never_shrinks_as_memory_grows(self):
+        """메모리가 늘었는데 고양이가 홀쭉해지면 안 된다. v0.3.0 의 버그다."""
+        prev = -1
+        for p in range(101):
+            body = desktop_cat.body_size_percent(
+                desktop_cat.SOURCE_MEMORY, memory=float(p), disk=0.0)
+            self.assertGreaterEqual(body, prev, f"메모리 {p}% 에서 거꾸로 갔습니다")
+            prev = body
+
+    def test_a_forty_picture_theme_still_moves_below_the_first_threshold(self):
+        """`derpy` 처럼 진짜 40장인 테마는 60% 아래에서도 움직여야 한다.
+
+        6장짜리 테마는 60% 아래가 전부 "A fine boi" 한 장이다(앱이 그렇게
+        정의해 두었다). 하지만 그림이 40장 있는 테마까지 한 자리에 묶어 둘
+        이유는 없다.
+        """
+        frames = {desktop_cat.frame_index_for(
+            "derpy", desktop_cat.body_size_percent(
+                desktop_cat.SOURCE_MEMORY, memory=float(p), disk=0.0))
+            for p in range(0, 60)}
+        self.assertGreater(
+            len(frames), 1, "60% 아래에서 40장짜리 테마가 얼어붙습니다")
 
 
 class MaxSourceBodyTests(unittest.TestCase):
@@ -519,72 +586,61 @@ class MaxSourceBodyTests(unittest.TestCase):
 
 
 class BodyPercentTests(unittest.TestCase):
-    """메모리로 몸집을 정할 때 홀쭉한 쪽 절반을 쓸 수 있는지.
+    """잰 값을 몸집 값으로 옮기는 자. 메모리·디스크가 **같은 자**를 쓴다.
 
-    메모리 사용률은 0 근처로 내려가지 않는다. 도는 맥은 늘 절반쯤 쓰고
-    있다. 0~100 을 그대로 프레임에 옮기면 고양이가 뚱뚱한 쪽에 갇힌다.
-
-    실측(18GB, macOS 15.4.1): 평상시 65~66%. 40프레임 테마에서 25번 —
-    이미 뚱뚱한 쪽이고, 30초 동안 1.0 포인트밖에 안 움직였다.
+    실측(18GB, macOS 15.4.1): 관측된 메모리가 61~80% 였고 재부팅 직후에도
+    80% 였다. 0~100 을 그대로 옮기면 사진 테마의 그림 여섯 장 중 두 장밖에
+    안 보인다.
     """
 
-    def test_the_floor_maps_to_the_thinnest_frame(self):
-        self.assertEqual(
-            desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY,
-                                     desktop_cat.MEMORY_FLOOR),
-            0.0)
+    def test_an_empty_machine_maps_to_the_thinnest_frame(self):
+        self.assertEqual(desktop_cat.body_percent(0.0), 0.0)
 
-    def test_full_memory_still_maps_to_the_fattest_frame(self):
-        self.assertEqual(
-            desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY, 100.0), 100.0)
+    def test_a_full_machine_maps_to_the_fattest_frame(self):
+        self.assertEqual(desktop_cat.body_percent(100.0), 100.0)
 
-    def test_below_the_floor_does_not_go_negative(self):
-        self.assertEqual(
-            desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY, 5.0), 0.0)
-
-    def test_disk_is_left_alone(self):
-        """디스크는 진짜로 0~100 을 다 쓴다. 눈금을 건드리면 안 된다."""
-        for percent in (0.0, 37.0, 65.0, 100.0):
+    def test_it_never_leaves_the_zero_to_hundred_range(self):
+        """엉뚱한 값이 와도 프레임 번호가 될 수 있어야 한다."""
+        for percent in (-100.0, -1.0, 0.0, 50.0, 100.0, 100.1, 500.0):
             with self.subTest(percent=percent):
-                self.assertEqual(
-                    desktop_cat.body_percent(desktop_cat.SOURCE_DISK, percent),
-                    percent)
+                value = desktop_cat.body_percent(percent)
+                self.assertGreaterEqual(value, 0.0)
+                self.assertLessEqual(value, 100.0)
 
-    def test_max_compares_two_raw_percentages(self):
-        """`max` 는 "둘 중 더 찬 쪽" 이다. 한쪽만 눈금을 바꾸면 비교가 깨진다."""
-        for percent in (20.0, 65.0, 90.0):
+    def test_memory_and_disk_share_one_ruler(self):
+        """자를 따로 쓰면 `max` 가 깨진다.
+
+        메모리만 눈금을 다시 매기면 메모리 71.5% 가 디스크 50% 에 진다.
+        "둘 중 더 찬 쪽" 이 사실상 디스크 전용이 된다.
+        """
+        for percent in (10.0, 50.0, 65.0, 71.5, 90.0, 99.0):
             with self.subTest(percent=percent):
-                self.assertEqual(
-                    desktop_cat.body_percent(desktop_cat.SOURCE_MAX, percent),
-                    percent)
+                mem = desktop_cat.body_size_percent(
+                    desktop_cat.SOURCE_MEMORY, memory=percent, disk=0.0)
+                dsk = desktop_cat.body_size_percent(
+                    desktop_cat.SOURCE_DISK, memory=0.0, disk=percent)
+                self.assertEqual(mem, dsk)
 
     def test_an_unknown_source_falls_back_the_same_way_size_percent_does(self):
-        """`size_percent` 와 같은 자를 써야 한다.
+        """`size_percent` 는 모르는 `source` 를 기본값으로 바꿔서 계산한다.
 
-        `size_percent` 는 모르는 `source` 를 기본값(메모리)으로 바꿔서 값을
-        낸다. `body_percent` 가 날값으로 비교하면 둘이 갈라진다 — 몸집을
-        정하는 값은 메모리인데 눈금은 안 바뀌는 상태가 된다.
-
-        `alert_icon_path` 는 `cfg.get("size_source")` 를 기본값 없이 넘긴다.
-        화면 위 고양이와 알럿 아이콘이 다른 몸집이 되는 길이고, 그건 이
-        수정이 없애려던 바로 그 증상이다.
+        `alert_icon_path` 가 `cfg.get("size_source")` 를 기본값 없이 넘기므로,
+        여기서 갈라지면 화면 위 고양이와 알럿 아이콘이 다른 몸집이 된다.
         """
-        expected = desktop_cat.body_percent(
-            desktop_cat.DEFAULT["size_source"], 65.5)
+        expected = desktop_cat.body_size_percent(
+            desktop_cat.DEFAULT["size_source"], memory=65.5, disk=20.0)
         for source in (None, "cpu", "", "MEMORY"):
             with self.subTest(source=source):
                 self.assertEqual(
-                    desktop_cat.body_percent(source, 65.5), expected,
-                    f"source={source!r} 가 size_percent 와 다른 자를 쓴다")
+                    desktop_cat.body_size_percent(source, memory=65.5, disk=20.0),
+                    expected)
 
     def test_an_idle_mac_is_not_stuck_in_the_fat_half(self):
-        """평상시 메모리에서 고양이가 홀쭉한 쪽에 있어야 한다.
-
-        이 검사가 깨지면 "앱을 닫으면 홀쭉해진다" 를 사람이 볼 수 없다.
-        """
+        """평상시 메모리에서 고양이가 홀쭉한 쪽에 있어야 한다."""
         frames = desktop_cat.frame_count("cute")
         idle = desktop_cat.frame_index_for(
-            "cute", desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY, 65.5))
+            "cute", desktop_cat.body_size_percent(
+                desktop_cat.SOURCE_MEMORY, memory=65.5, disk=0.0))
         self.assertLess(
             idle, (frames - 1) / 2,
             f"평상시 메모리 65.5% 가 {frames}프레임 중 {idle}번 — 뚱뚱한 쪽이다")
@@ -599,9 +655,11 @@ class CatMovementTests(unittest.TestCase):
         실제로 프레임을 구한다.
         """
         before = desktop_cat.frame_index_for(
-            "cute", desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY, 80.0))
+            "cute", desktop_cat.body_size_percent(
+                desktop_cat.SOURCE_MEMORY, memory=80.0, disk=0.0))
         after = desktop_cat.frame_index_for(
-            "cute", desktop_cat.body_percent(desktop_cat.SOURCE_MEMORY, 63.8))
+            "cute", desktop_cat.body_size_percent(
+                desktop_cat.SOURCE_MEMORY, memory=63.8, disk=0.0))
         moved = before - after
         # 눈금을 다시 매기기 전에는 6칸이었다. 사람 눈에 확실히 보이려면
         # 그보다 더 움직여야 한다.
@@ -1761,24 +1819,23 @@ class RevealTests(unittest.TestCase):
             # 값을 손으로 적어 둔다. 여기서 body_percent 를 다시 부르면
             # 제품 코드를 그대로 베낀 검사가 되어 아무것도 못 잡는다.
             #
-            # 메모리는 눈금을 다시 매긴다(MEMORY_FLOOR=40). 도는 맥은 메모리를
-            # 0 근처까지 비우지 않으므로, 40 아래를 전부 제일 홀쭉한 프레임에
-            # 몰아 두고 40~100 을 11프레임에 편다. 디스크는 진짜로 0~100 을
-            # 다 쓰므로 그대로 둔다.
-            cases_by_source = {
-                desktop_cat.SOURCE_MEMORY: {
-                    0.0: "cat_00.png",    # 바닥 아래 -> 제일 홀쭉
-                    50.0: "cat_02.png",   # (50-40)/60 = 16.7%
-                    91.0: "cat_08.png",   # (91-40)/60 = 85.0%
-                    100.0: "cat_10.png",
-                },
-                desktop_cat.SOURCE_DISK: {
-                    0.0: "cat_00.png", 50.0: "cat_05.png",
-                    91.0: "cat_09.png", 100.0: "cat_10.png",
-                },
+            # 메모리는 이름 문턱(60/70/80/90/96)에 맞춰 그림 구간에 옮긴다.
+            # 도는 맥은 메모리를 0 근처까지 비우지 않으므로 0~100 을 그대로
+            # 쓰면 그림 여섯 장 중 두 장밖에 안 보인다. 디스크는 진짜로
+            # 0~100 을 다 쓰므로 그대로 둔다.
+            # 값을 손으로 적어 둔다. 여기서 body_percent 를 다시 부르면
+            # 제품 코드를 그대로 베낀 검사가 되어 아무것도 못 잡는다.
+            #
+            # 이름 문턱(60/70/80/90/96)에 맞춰 그림 구간에 옮긴다. 메모리와
+            # 디스크가 같은 자를 쓰므로 표도 하나다.
+            cases = {
+                0.0: "cat_00.png",
+                50.0: "cat_01.png",   # 60% 아래 = 첫 그림 구간 안
+                91.0: "cat_07.png",   # 90~96 구간의 초입
+                100.0: "cat_10.png",
             }
-            # 아이콘도 설정이 고른 지표를 따라야 한다. 화면 위 고양이는 메모리로
-            # 부풀어 있는데 말 거는 창에는 홀쭉한 그림이 붙으면 따로 논다.
+            cases_by_source = {desktop_cat.SOURCE_MEMORY: cases,
+                               desktop_cat.SOURCE_DISK: cases}
             for source, cases in cases_by_source.items():
                 for percent, expected in cases.items():
                     with self.subTest(source=source, percent=percent):


### PR DESCRIPTION
## 알아낸 것 — 그림은 여섯 장이다

사진으로 만든 테마는 **40프레임이 아니라 그림 여섯 장**이다. 34개는 복제본이다. 해시로 확인했다.

| 테마 | 파일 | 서로 다른 그림 |
|---|---|---|
| cute (기본) | 40 | **6장** |
| simple | 40 | **6장** |
| mypet (사용자가 사진으로 만든 것) | 40 | **6장** |
| gandi-v2 | 40 | **5장** |
| derpy | 40 | 40장 |
| madness | 40 | 40장 |

`import_theme.save_theme_frames` 가 `smooth=False` 로 가장 가까운 단계를 그대로 쓴다. 섞으면 귀와 눈이 겹쳐 유령처럼 보이기 때문이고, 그건 옳은 판단이다. `vision_theme` 도 그 기본값으로 부르므로 **커스텀 테마도 전부 여섯 장이다.** 40장짜리는 코드로 그린 두 개뿐이다.

그러면 "몇 프레임 움직이나" 는 뜻이 없다. **어느 그림을 보여주나** 가 전부다. 이 맥에서 관측된 61~80% 를 재 보면:

| | 그림 |
|---|---|
| 선형 (v0.3.1) | 2장 |
| 바닥40 (지금 main) | 2장 |
| **이 PR** | **3장** |

## 무엇을 고쳤나

`MEMORY_FLOOR = 40` 을 지웠다. 이 맥 한 대에서 잰 값을 상수로 박은 것이었고, 근거가 없고, 40% 아래가 전부 한 그림으로 눌렸다.

대신 메모리 구간을 그림 구간에 하나씩 대응시킨다. 경계는 `i18n.chonk_stage` 의 문턱을 그대로 쓴다 — 지어낸 숫자가 아니라 앱이 이미 정해 둔 값이다.

```
그림 바뀜: 60, 70, 80, 90, 96
이름 바뀜: 60, 70, 80, 90, 96
```

**"HEFTYCHONK" 이 뜨는 순간 몸이 그 그림이 된다.** 구간 안에서는 직선이라 `derpy` 처럼 진짜 40장인 테마는 계속 부드럽게 움직인다.

### 디스크도 같은 자를 쓴다

메모리만 눈금을 바꾸면 자가 두 개가 되어 `max` 가 깨진다 — **메모리 71.5% 가 디스크 50% 에 지고** "둘 중 더 찬 쪽" 이 사실상 디스크 전용이 된다. 앱은 이미 디스크에도 같은 문턱으로 이름을 붙이고 있다(`brain.collect_metrics` 의 `chonk_stage(disk.percent)`).

화면에 적히는 숫자는 그대로다. 정보창의 "RAM 65%" 와 기분 줄은 잰 값을 쓴다.

## 검사

새로 넣은 것: 그림 경계 == 이름 경계 / 그림 여섯 장 전부 도달 가능 / 메모리가 늘 때 몸집이 거꾸로 안 감 / 40장 테마는 첫 문턱 아래에서도 움직임 / 메모리와 디스크가 같은 자.

변형으로 확인했다:

| 되돌린 것 | 깨지는 검사 |
|---|---|
| 문턱을 이름과 어긋나게 | 1개 |
| 디스크만 자를 따로 | 9개 |
| 선형으로 되돌리기 | 8개 |

**213 passed, 5 skipped.**

## 남은 한계 (v0.4)

그림이 여섯 장이라 매핑을 어떻게 짜도 20포인트 구간에서 3장이 최대다. 산수라 못 넘는다. 진짜 해결은 단계 수를 늘리는 것이고, 구조는 이미 유연하다 — `segments()` 가 시트의 마리 수를 자동으로 세고 `save_theme_frames` 가 개수와 무관하게 동작한다. `vision_theme.py` 의 프롬프트만 "six times" 로 박혀 있다. 별도 이슈로 남긴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)