### PR TITLE
fix: 한국어 단계를 그림 문턱에 맞춰 6단계로 맞춘다

### DIFF
--- a/i18n.py
+++ b/i18n.py
@@ -18,14 +18,27 @@ CHONK_STAGES_EN = (
     "OH LAWD HE COMIN",
 )
 
+#: 한국어 단계. 영어의 chonk chart 는 밈이라 그대로 두고, 한국어는 배부름
+#: 비유로 간다. **개수와 문턱이 영어와 같아야 한다** — `desktop_cat.body_percent`
+#: 가 이 문턱(60/70/80/90/96)에서 그림을 바꾸므로, 한쪽만 단계를 줄이면
+#: 그림과 이름이 따로 논다. v0.3.2 까지 한국어가 4 단계라 실제로 그랬다.
+CHONK_STAGES_KO = (
+    "아직 더 먹을 수 있어요",
+    "살짝 배불러요",
+    "좀 더 배불러요",
+    "이제 진짜 배불러요",
+    "슬슬 잠이 와요",
+    "졸려요",
+)
+
 _STRINGS = {
     "ko": {
         "disk": "디스크",
         "ram": "램",
         "swap": "스왑",
         "free": "여유",
-        "mood": "기분",
-        "mood_detail": "기분: {mood}  ({source} {percent}%)",
+        "mood": "상태",
+        "mood_detail": "상태: {mood}  ({source} {percent}%)",
         "source_memory": "메모리",
         "source_disk": "디스크",
         "source_max": "메모리·디스크",
@@ -342,24 +355,24 @@ def pet_name(configured: Optional[str], language: str) -> str:
 
 
 def chonk_stage(percent: float, language: str) -> str:
-    """한국어는 기존 4단계를 유지하고 영어만 6단계 chonk chart를 쓴다."""
+    """두 언어 모두 6단계. 문턱은 60/70/80/90/96 으로 같다.
+
+    `desktop_cat.body_percent` 가 같은 문턱에서 그림을 바꾸므로, 이름이
+    바뀌는 지점과 몸이 바뀌는 지점이 언어와 상관없이 일치한다.
+    """
     if canonical_language(language) == LANGUAGE_KO:
-        if percent < 60:
-            return "여유"
-        if percent < 80:
-            return "포동"
-        if percent < 92:
-            return "배불러"
-        return "빵빵!"
+        stages = CHONK_STAGES_KO
+    else:
+        stages = CHONK_STAGES_EN
 
     if percent < 60:
-        return CHONK_STAGES_EN[0]
+        return stages[0]
     if percent < 70:
-        return CHONK_STAGES_EN[1]
+        return stages[1]
     if percent < 80:
-        return CHONK_STAGES_EN[2]
+        return stages[2]
     if percent < 90:
-        return CHONK_STAGES_EN[3]
+        return stages[3]
     if percent < 96:
-        return CHONK_STAGES_EN[4]
-    return CHONK_STAGES_EN[5]
+        return stages[4]
+    return stages[5]

--- a/tests/test_desktop_cat.py
+++ b/tests/test_desktop_cat.py
@@ -503,15 +503,24 @@ class BodyFollowsChonkStagesTests(unittest.TestCase):
         self.fail(f"프레임 {frame} 이 어느 그림에도 안 들어갑니다")
 
     def test_the_picture_changes_exactly_where_the_name_changes(self):
+        """두 언어를 다 본다.
+
+        v0.3.2 까지 한국어 이름은 4 단계(60/80/92)라 그림(60/70/80/90/96)과
+        따로 놀았다. 이 검사가 영어만 봐서 아무도 못 잡았다.
+        """
         picture_at = [self._picture(float(p)) for p in range(101)]
-        name_at = [i18n.chonk_stage(float(p), "en") for p in range(101)]
         picture_edges = [p for p in range(1, 101)
                          if picture_at[p] != picture_at[p - 1]]
-        name_edges = [p for p in range(1, 101)
-                      if name_at[p] != name_at[p - 1]]
-        self.assertEqual(
-            picture_edges, name_edges,
-            f"그림은 {picture_edges} 에서 바뀌는데 이름은 {name_edges} 에서 바뀝니다")
+        for language in ("en", "ko"):
+            with self.subTest(language=language):
+                name_at = [i18n.chonk_stage(float(p), language)
+                           for p in range(101)]
+                name_edges = [p for p in range(1, 101)
+                              if name_at[p] != name_at[p - 1]]
+                self.assertEqual(
+                    picture_edges, name_edges,
+                    f"[{language}] 그림은 {picture_edges} 에서 바뀌는데 "
+                    f"이름은 {name_edges} 에서 바뀝니다")
 
     def test_every_picture_is_reachable(self):
         """그림 6장이 다 쓰여야 한다. 안 쓰이는 그림이 있으면 낭비다."""

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -112,12 +112,20 @@ class I18nTests(unittest.TestCase):
         stages = [i18n.chonk_stage(value, "en") for value in (50, 65, 75, 85, 92, 99)]
         self.assertEqual(tuple(stages), i18n.CHONK_STAGES_EN)
 
+    def test_korean_chart_uses_all_six_exact_stage_names(self):
+        # 영어와 같은 표본값을 쓴다. 단계마다 하나씩 짚어야 문턱이 밀렸을 때
+        # 잡힌다 — 표본이 모자라면 안 불리는 단계가 검사 밖에 남는다.
+        stages = [i18n.chonk_stage(value, "ko") for value in (50, 65, 75, 85, 92, 99)]
+        self.assertEqual(tuple(stages), i18n.CHONK_STAGES_KO)
+
+    def test_the_two_languages_have_the_same_number_of_stages(self):
+        """개수가 갈라지면 한쪽 언어에서 그림과 이름이 따로 논다."""
+        self.assertEqual(len(i18n.CHONK_STAGES_KO), len(i18n.CHONK_STAGES_EN))
+
     def test_korean_growth_stages_carry_no_animal_emoji(self):
         # 사진으로 만든 테마는 고양이가 아닐 수 있다. 고양이 이모지가 붙어
         # 있으면 수달한테 냥이라고 부르는 꼴이 된다.
-        stages = [i18n.chonk_stage(value, "ko") for value in (50, 70, 85, 95)]
-        self.assertEqual(stages, ["여유", "포동", "배불러", "빵빵!"])
-        for stage in stages:
+        for stage in i18n.CHONK_STAGES_KO:
             with self.subTest(stage=stage):
                 self.assertTrue(all(ord(ch) < 0x1F300 for ch in stage))
 


### PR DESCRIPTION
## 무엇이 문제였나

v0.3.2 가 "이름 바뀌는 지점 = 그림 바뀌는 지점" 으로 맞춘 건 **영어뿐**이었습니다.

| | 그림 바뀜 | 이름 바뀜 |
|---|---|---|
| 영어 | 60/70/80/90/96 | 60/70/80/90/96 ✅ |
| 한국어 | 60/70/80/90/96 | **60/80/92** ❌ |

`test_the_picture_changes_exactly_where_the_name_changes` 가 영어만 봐서 못 잡았습니다.

## 무엇을 했나

- 한국어를 4단계 → **6단계**, 문턱을 영어와 같은 60/70/80/90/96 으로
- 두 언어가 **같은 문턱 체인**을 쓰게 정리 (앞으로 갈라질 수 없음)
- `CHONK_STAGES_KO` 를 상수로 분리 — `if` 문 안에 박힌 문자열은 테스트가 개수도 이름도 못 잡습니다
- 라벨 `기분:` → `상태:`

```
~60%  아직 더 먹을 수 있어요     A fine boi
 60%  살짝 배불러요             He chomnk
 70%  좀 더 배불러요            A heckin' chonker
 80%  이제 진짜 배불러요         HEFTYCHONK
 90%  슬슬 잠이 와요            MEGACHONKER
 96%  졸려요                   OH LAWD HE COMIN
```

영어 chonk chart 는 밈이라 **그대로 뒀습니다.**

## 검증

RED → GREEN 순서로 갔습니다. 먼저 한국어 검사를 넣어 실패를 확인:

```
[ko] 그림은 [60, 70, 80, 90, 96] 에서 바뀌는데 이름은 [60, 80, 92] 에서 바뀝니다
```

고친 뒤: `215 passed, 5 skipped, 118 subtests passed` (213 → 테스트 2개 추가)

**변형 감사** — 검사가 헛돌지 않는지 일부러 망가뜨려 확인했습니다:

| 변형 | 잡혔나 |
|---|---|
| 한국어 문턱 90 → 88 | ✅ 일치 검사 |
| 이름 하나 빼서 5단계 | ✅ 이름 대조 + 개수 검사 |
| 영어 문턱 96 → 94 | ✅ 일치 검사 |

**정보창 줄 렌더 확인** — 새 이름이 길어도 영어보다 짧습니다:

```
상태: 아직 더 먹을 수 있어요  (메모리 55%)   28자
Chonk: OH LAWD HE COMIN  (Disk 97%)        35자
```

## 범위 밖 (윈도우)

윈도우는 디스크를 프레임에 **선형으로** 꽂습니다 (`windows_cat.pyw:219`) — 그림이 9/30/50/71/92 에서 바뀝니다. `body_percent` 를 안 씁니다.

따라서 이 PR 로도 윈도우는 여전히 어긋납니다. 고치려면 `body_percent` 를 `metrics.py` 로 옮겨야 하는데, 그러면 **디스크 60% 미만 사용자는 제일 홀쭉한 그림 하나만** 보게 됩니다. 눈으로 보고 정할 문제라 별도 이슈로 둡니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)