### PR TITLE
release: v0.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # 가상환경 / 캐시
 .venv/
+# 릴리스 zip 을 굽는 전용 venv (python.org 3.12). requirements-release.txt 참고
+.relvenv/
 __pycache__/
 *.pyc
 

--- a/macos/build_app.py
+++ b/macos/build_app.py
@@ -52,7 +52,7 @@ INTERPRETER_NAME = "MemoryCatPython"
 PYTHON_HOME_FILE = "pythonhome"
 # 릴리스 빌드(macos/memorycat.spec)와 같은 값이어야 한다. 두 경로가 서로 다른
 # 버전을 새기면 사용자가 어느 쪽으로 설치했는지 구별할 수 없다.
-VERSION = "0.3.2"
+VERSION = "0.3.3"
 
 #: 번들 안에서의 아이콘 파일 이름. ``CFBundleIconFile`` 에 이 값이 그대로
 #: 들어간다. 확장자를 붙여 둔다 — 애플 문서가 허용하는 형태고(크롬도

--- a/macos/memorycat.spec
+++ b/macos/memorycat.spec
@@ -54,7 +54,7 @@ from pathlib import Path
 REPO = Path(SPECPATH).resolve().parent  # noqa: F821  (SPECPATH is injected)
 
 # 릴리스 태그와 반드시 같이 움직여야 하는 값. 태그를 올리면 여기도 올린다.
-VERSION = "0.3.2"
+VERSION = "0.3.3"
 
 # 번들이 요구하는 최소 macOS. **아키텍처마다 다르다.**
 #


### PR DESCRIPTION
버전을 0.3.3 으로 올린다. 두 빌드 경로 모두 (`macos/build_app.py`, `macos/memorycat.spec`) — `test_both_build_paths_stamp_the_same_version` 가 지킨다.

## 이 릴리스에 들어가는 것

- #38 한국어 단계를 그림 문턱에 맞춰 6단계로 (`기분:` → `상태:`)
- #39 README 를 릴리스 노트와 같은 말을 하게

## 빌드 검증 (ARM)

```
인터프리터   python.org 3.12.10 arm64   ← Homebrew 아님
minos       11.0                        ← vtool -show-build 로 직접 확인
번들 검사    218 passed, 2 skipped       (MEMORY_CAT_REQUIRE_BUNDLE=1)
포장        ditto -c -k --sequesterRsrc --keepParent
서명        valid on disk / satisfies its Designated Requirement
실물 실행    압축을 풀어 실행 → 8초 생존, 새 에러 로그 0 건
크기        39M
```

```
SHA-256  85c76e1052c241256eff87c93050b9a3599643e497acfd5f424f129d29096822
Memory-Cat-macOS-AppleSilicon.zip
```

인텔·윈도우는 `release: published` 이벤트로 GitHub Actions 가 굽는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)